### PR TITLE
Register special access (read/write side effect)

### DIFF
--- a/PyICe/lab_core.py
+++ b/PyICe/lab_core.py
@@ -928,7 +928,7 @@ class register(integer_channel):
         self._read = None
         self.set_read_access(True)
         self.set_attribute('read_caching', True)
-    def set_special_access(self, acess):
+    def set_special_access(self, access):
         '''
         following uvm_reg_field convention
         https://verificationacademy.com/verification-methodology-reference/uvm/docs_1.1a/html/files/reg/uvm_reg_field-svh.html

--- a/PyICe/lab_core.py
+++ b/PyICe/lab_core.py
@@ -975,11 +975,11 @@ class register(integer_channel):
 
         # special read behavior    
         elif access.upper() in ("RC", "RS", "WRC", "WRS"):
-            raise Exception('Read side effect special register access unimplemented. Please contact PyICe developers.')
+            raise Exception(f'Read side effect {access.upper()} special register access unimplemented. Please contact PyICe developers.')
         
         # special write behavior
         elif access.upper() in ("WC", "WS", "W1T", "W0T", "WOC", "WOS", "W1", "WO1"):
-            raise Exception('Limited write side effect special register access implemented. Please contact PyICe developers.')
+            raise Exception(f'Limited write side effect special register access implemented. {access.upper()} not yet implemented. Please contact PyICe developers.')
         elif access.upper() == "W1C":
             self.set_attribute('special_access', 'W1C')
             self.set_read_access(True)
@@ -1008,6 +1008,23 @@ class register(integer_channel):
         else:
             raise Exception('Unknown register side effect special access.. Please contact PyICe developers.')
     def compute_rmw_writeback_data(self, data):
+        '''Bitfield level callback to modify writeback data for read-modify-write sub-atomic register access. This is useful primarily for bitfields with write side effects implemented.
+           
+        Parameters
+        ----------
+        data : int
+            Bitfield readback data, masked and shifted to LSB position.
+        
+        Returns
+        -------
+        int
+            Bitfield writeback data. Usually the same as readback data.
+
+        Raises
+        -------
+        Exception
+            Unknown value contained in "special_access" channel attribute.
+        '''
         if self.get_attribute('special_access') is None:
             return data
         elif self.get_attribute('special_access') in ('W1C','W1S'):
@@ -1015,7 +1032,7 @@ class register(integer_channel):
         elif self.get_attribute('special_access') in ('W0C','W0S'):
             return 2**self.get_size()-1
         else:
-            raise Exception(f'Resister special access {self.get_attribute("special_access")} improperly implemented. Contact PyICe developers.')
+            raise Exception(f'Register special access {self.get_attribute("special_access")} improperly implemented. Contact PyICe developers.')
 
 class channel_group(object):
     def __init__(self, name='Unnamed Channel Group'):

--- a/PyICe/twi_instrument.py
+++ b/PyICe/twi_instrument.py
@@ -173,6 +173,39 @@ class twi_instrument(lab_core.instrument,lab_core.delegator):
     def get_bitfield_writeback_data(self, addr7, data, command_code, size, offset, word_size):
         raise Exception('Code cleanup 2024/05/08. Switch to new method name compute_rmw_writeback_data() with new calling and return signature.')
     def compute_rmw_writeback_data(self, data, addr7, command_code, size, offset, word_size, is_readable=True, overwrite_others=False):
+        '''Read whole (atmoic) register. 
+        Replace any slices unrelated to the write slice based on each constituent bitfield's RWM value preference
+        Replace slice related to the write with the new data.
+
+        Parameters
+        ----------
+        data : int
+            Bitfield write data, right aligned.
+        addr7 : int
+            Chip address in 7-bit (no R/W bit) format.
+        command_code : int
+            Memory address of register/bitfield
+        size : int
+            Slice width of bitfield within register
+        offset : int
+            LSB position of bitfield slice within register
+        word_size : int
+            Register width
+        is_readable : bool
+            Does register have read access?
+        overwrite_others : bool
+            Skip readback. Instead assume register content is 0 before replacing slices.
+
+        Returns
+        -------
+        (int, int)
+            Register writeback data and command code tuple.
+
+        Raises
+        -------
+        Exception
+            Various consistency errors. Abnormal.
+        '''
         # Step 1: get existing data across whole register width
         if data is None and word_size == 0:
             #send_byte

--- a/PyICe/twi_instrument.py
+++ b/PyICe/twi_instrument.py
@@ -381,29 +381,36 @@ class twi_instrument(lab_core.instrument,lab_core.delegator):
                 is_readable = "R" in bf['access']
                 is_writable = "W" in bf['access']
                 register = self.add_register(name,slave_addr,command_code,size,offset,word_size,is_readable,is_writable,overwrite_others)
+
                 
-                if bf['write_side_effect'] == 'None':
+                try:
+                    bf['writey_side_effect']
+                except KeyError as e:
+                    # Old schema
                     pass
-                elif bf['write_side_effect'] == 'OneToClear':
-                    assert is_readable, f'Unexpected W1C register without read access: {name}. Contact PyICe developers.'
-                    assert is_writable, f'Unexpected W1C register without write access: {name}. Contact PyICe developers.'
-                    register.set_special_access('W1C')
-                elif bf['write_side_effect'] == 'OneToSet':
-                    assert is_readable, f'Unexpected W1S register without read access: {name}. Contact PyICe developers.'
-                    assert is_writable, f'Unexpected W1S register without write access: {name}. Contact PyICe developers.'
-                    register.set_special_access('W1S')
-                elif bf['write_side_effect'] == 'ZeroToClear':
-                    assert is_readable, f'Unexpected W0C register without read access: {name}. Contact PyICe developers.'
-                    assert is_writable, f'Unexpected W0C register without write access: {name}. Contact PyICe developers.'
-                    register.set_special_access('W0C')
-                elif bf['write_side_effect'] == 'ZeroToSet':
-                    assert is_readable, f'Unexpected W0S register without read access: {name}. Contact PyICe developers.'
-                    assert is_writable, f'Unexpected W0S register without write access: {name}. Contact PyICe developers.'
-                    register.set_special_access('W0S')
-                elif bf['write_side_effect'] in ('OneToToggle', 'ZeroToToggle', 'Clear', 'Set'):
-                    raise Exception(f'Register side effect {bf["write_side_effect"]} not implemented. Contact PyICe developers.')
                 else:
-                    raise Exception(f'Register side effect {bf["write_side_effect"]} unknown. Contact PyICe developers.')
+                    if bf['write_side_effect'] == 'None':
+                        pass
+                    elif bf['write_side_effect'] == 'OneToClear':
+                        assert is_readable, f'Unexpected W1C register without read access: {name}. Contact PyICe developers.'
+                        assert is_writable, f'Unexpected W1C register without write access: {name}. Contact PyICe developers.'
+                        register.set_special_access('W1C')
+                    elif bf['write_side_effect'] == 'OneToSet':
+                        assert is_readable, f'Unexpected W1S register without read access: {name}. Contact PyICe developers.'
+                        assert is_writable, f'Unexpected W1S register without write access: {name}. Contact PyICe developers.'
+                        register.set_special_access('W1S')
+                    elif bf['write_side_effect'] == 'ZeroToClear':
+                        assert is_readable, f'Unexpected W0C register without read access: {name}. Contact PyICe developers.'
+                        assert is_writable, f'Unexpected W0C register without write access: {name}. Contact PyICe developers.'
+                        register.set_special_access('W0C')
+                    elif bf['write_side_effect'] == 'ZeroToSet':
+                        assert is_readable, f'Unexpected W0S register without read access: {name}. Contact PyICe developers.'
+                        assert is_writable, f'Unexpected W0S register without write access: {name}. Contact PyICe developers.'
+                        register.set_special_access('W0S')
+                    elif bf['write_side_effect'] in ('OneToToggle', 'ZeroToToggle', 'Clear', 'Set'):
+                        raise Exception(f'Register side effect {bf["write_side_effect"]} not implemented. Contact PyICe developers.')
+                    else:
+                        raise Exception(f'Register side effect {bf["write_side_effect"]} unknown. Contact PyICe developers.')
                 try:
                     register.add_write_callback(self._interface.ivy_session._textwave)
                 except AttributeError as e:


### PR DESCRIPTION
Add subset "RO", "WO", "RW", "W1C", "W1S", "W0C", "W0S"
of:
	”RO”	W: no effect	R: no effect
	”RW”	W: as-is	R: no effect
	”RC”	W: no effect	R: clears all bits
	”RS”	W: no effect	R: sets all bits
	”WRC”	W: as-is	R: clears all bits
	”WRS”	W: as-is	R: sets all bits
	”WC”	W: clears all bits	R: no effect
	”WS”	W: sets all bits	R: no effect
	”WSRC”	W: sets all bits	R: clears all bits
	”WCRS”	W: clears all bits	R: sets all bits
	”W1C”	W: 1/0 clears/no effect on matching bit	R: no effect
	”W1S”	W: 1/0 sets/no effect on matching bit	R: no effect
	”W1T”	W: 1/0 toggles/no effect on matching bit	R: no effect
	”W0C”	W: 1/0 no effect on/clears matching bit	R: no effect
	”W0S”	W: 1/0 no effect on/sets matching bit	R: no effect
	”W0T”	W: 1/0 no effect on/toggles matching bit	R: no effect
	”W1SRC”	W: 1/0 sets/no effect on matching bit	R: clears all bits
	”W1CRS”	W: 1/0 clears/no effect on matching bit	R: sets all bits
	”W0SRC”	W: 1/0 no effect on/sets matching bit	R: clears all bits
	”W0CRS”	W: 1/0 no effect on/clears matching bit	R: sets all bits
	”WO”	W: as-is	R: error
	”WOC”	W: clears all bits	R: error
	”WOS”	W: sets all bits	R: error
	”W1”	W: first one after HARD reset is as-is, other W have no effects	R: no effect
	”WO1”	W: first one after HARD reset is as-is, other W have no effects	R: error
resister side effect behavior.