### PR TITLE
Skip cleanup

### DIFF
--- a/PyICe/plugins/master_test_template.py
+++ b/PyICe/plugins/master_test_template.py
@@ -41,7 +41,7 @@ class Master_Test_Template():
         if hasattr(self, '_module_path'):
             return self._module_path
         else:
-            print(f'No database file has been assigned to {self.get_name()} at this time. One is assigned upon adding a test to the plugin manager.')
+            print(f"Attempted to access the module path for {self.get_name()}. It would be created upon adding a test to the plugin manager but you didn't get that far.")
     def get_debug(self):
         return self._debug
     def get_verbose(self):
@@ -50,12 +50,12 @@ class Master_Test_Template():
         if hasattr(self, '_db_file'):
             return self._db_file
         else:
-            print(f'No database file has been assigned to {self.get_name()} at this time. One is assigned upon adding a test to the plugin manager.')
+            print(f"Attempted to access the database file for {self.get_name()}. It would be created upon adding a test to the plugin manager but you didn't get that far.")
     def get_database(self):
         if hasattr(self, '_db'):
             return self._db
         else:
-            print(f'No database has been assigned to {self.get_name()} at this time. One is assigned during evaluation or plotting.')
+            print(f"Attempted to access the database for {self.get_name()}. It's only intended to be accessible from inside the plot() or evaluate() methods.")
     def get_table_name(self):
         if hasattr(self, '_table_name'):
             return self._table_name

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -281,7 +281,6 @@ class Plugin_Manager():
         found_both = 0
         for (dirpath, dirnames, filenames) in os.walk(project_path):
             if 'always_notify.py' in filenames:
-                breakpoint()
                 globalnotificationpath = dirpath.replace(os.sep, '.')
                 globalnotificationpath = globalnotificationpath[globalnotificationpath.index(project_path.split(os.sep)[-1]):]
                 module = importlib.import_module(name=globalnotificationpath+f'.always_notify', package=None)
@@ -291,7 +290,6 @@ class Plugin_Manager():
                 if found_both==2:
                     break
             if self.operator+'.py' in filenames: 
-                breakpoint()
                 usernotificationpath = dirpath.replace(os.sep, '.')
                 usernotificationpath = usernotificationpath[usernotificationpath.index(project_path.split(os.sep)[-1]):]
                 module = importlib.import_module(name=usernotificationpath+f'.{self.operator}', package=None)

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -131,6 +131,7 @@ class Plugin_Manager():
         The special channel actions are functions that are run on each logging of data and the value is a dicionary with a channel object or the string name of a channel as key, and the value the function to be run. The function requires the arguments channel_name, readings, and test.'''
 
         self.cleanup_fns = []
+        self.temp_run_fns = []
         self.startup_fns = []
         self.shutdown_fns = []
         self.temperature_channel = None
@@ -159,6 +160,9 @@ class Plugin_Manager():
                     if 'cleanup_list' in instrument_dict:
                         for fn in instrument_dict['cleanup_list']:
                             self.cleanup_fns.append(fn)
+                    if 'temperature_run_startup_list' in instrument_dict:
+                        for fn in instrument_dict['temperature_run_startup_list']:
+                            self.temp_run_fns.append(fn)
                     if 'startup_list' in instrument_dict:
                         for fn in instrument_dict['startup_list']:
                             self.startup_fns.append(fn)
@@ -193,6 +197,16 @@ class Plugin_Manager():
             test.customize()
         test._logger.new_table(table_name=test.get_name(), replace_table=True)
         test._logger.write_html(file_name=f"{test.get_module_path()}{os.sep}scratch{os.sep}{self.project_folder_name}.html")
+
+    def temperature_run_startup(self):
+        for func in self.temp_run_fns:
+            try:
+                func()
+            except:
+                print("\n\PyICE Plugin Manager: One or more temperature start functions not executable. See list below.\n")
+                for function in self.temp_run_fns:
+                    print(function)
+                exit()
 
     def startup(self):
         for func in self.startup_fns:
@@ -526,6 +540,8 @@ class Plugin_Manager():
                 for test in self.tests:
                     self.visualizer.generate(file_base_name="Bench_Config", prune=True, file_format='svg', engine='neato', file_location=test._module_path+os.sep+'scratch')
             far_enough = True
+            if len(temperatures):
+                self.temperature_run_startup()
             for temp in temperatures or ["ambient"]:
                 if temp != "ambient":
                     print_banner(f'Setting temperature to {temp}°C')

--- a/PyICe/plugins/test_results.py
+++ b/PyICe/plugins/test_results.py
@@ -378,3 +378,11 @@ class Test_Results(generic_results):
                                               )
         self._test_results[name].append(new_result_record)
         return new_result_record
+        
+class Failed_Eval(Test_Results):
+    def __init__(self, test):
+        self.test = test
+    def __str__(self):
+        return f'Evaluation method itself failed for {self.test.get_name()}.\n\n'
+    def __bool__(self):
+        return False

--- a/PyICe/twi_interface.py
+++ b/PyICe/twi_interface.py
@@ -1128,7 +1128,6 @@ class i2c_scpi(twi_interface):
         self.interface.close()
     def init_i2c(self):
         self.reset_twi()
-        time.sleep(0.1)
         #modified this to remove the pyserial inWaiting, now its a plain visa interface
         timeout = self.interface.timeout
         self.interface.timeout = 0.02
@@ -1140,7 +1139,6 @@ class i2c_scpi(twi_interface):
         self.interface.timeout = timeout
     def resync_communication(self):
         print("***** i2c_scpi: Attempting RE-SYNC *****")
-        time.sleep(0.1)
         self.init_i2c()
     def close(self):
         '''close the underlying (serial) interface'''

--- a/PyICe/twi_interface.py
+++ b/PyICe/twi_interface.py
@@ -1118,13 +1118,12 @@ class i2c_pic(twi_interface):
         data16 = (msb << 8) + lsb
         return data16
 class i2c_scpi(twi_interface):
-    '''communication class to simplify talking to atmega32u4 with Steve/Eric SCPI firmware
-    requires pySerial
-    '''
+    '''communication class to simplify talking to atmega32u4 with Steve/Eric SCPI firmware requires pySerial'''
     def __init__(self, visa_interface, **kwargs):
         self.interface = visa_interface
         self._cc_list = None
         super().__init__(name="Configurator MCU native i2c port", **kwargs)
+        self.set_frequency(400e3)
     def __del__(self):
         self.interface.close()
     def init_i2c(self):
@@ -1140,8 +1139,8 @@ class i2c_scpi(twi_interface):
             pass
         self.interface.timeout = timeout
     def resync_communication(self):
-        print("***** Attempting RE-SYNC")
-        time.sleep(1.0)
+        print("***** i2c_scpi: Attempting RE-SYNC *****")
+        time.sleep(0.1)
         self.init_i2c()
     def close(self):
         '''close the underlying (serial) interface'''
@@ -1162,9 +1161,8 @@ class i2c_scpi(twi_interface):
         FCLK = 16e6
         TWBR = int(round(((FCLK / frequency - 16) / 2)))
         assert TWBR <= 255 and TWBR >= 0
-        self.interface.write(':I2C:PORT:TWBR {};'.format(TWBR))
+        self.interface.write(f':I2C:PORT:TWBR {TWBR};')
         self.reset_twi()
-        print("Setting I2C port to {}Hz".format(FCLK / (16 + 2 * TWBR)))
     ###I2C Primitives###
     def start(self):
         self.interface.write(':S?;')


### PR DESCRIPTION
Adds the "always_notify" to the find_notifications method. Turns the email and text targets into a set after aggregating.

Adds a "far_enough" flag to skip cleanup and shutdown methods if one tries to run them before any changes were made to the bench. This prevents crashes during these methods that would distract from the root cause of the crash.