### PR TITLE
Connection checker helper file

### DIFF
--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -71,6 +71,7 @@ class Plugin_Manager():
         The list consists of values that will be set to the 'temp_control_channel' assigned by the instrument drivers.
         Default value is an empty list.
         '''
+        self._temperatures = temperatures
         self.collect(temperatures)
         self.plot()
         if 'evaluate_tests' in self.plugins:

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -475,7 +475,7 @@ class Plugin_Manager():
                     plot_script_src += f"from {import_str}.test import Test\n"
                     plot_script_src += f"pm = Plugin_Manager(settings=Project_Settings)\n"
                     plot_script_src += f"pm.add_test(Test)\n"
-                    plot_script_src += f"pm.plot(database='data_log.sqlite', table_name='{archived_table_name}')\n"
+                    plot_script_src += f"pm.plot(database='data_log.sqlite', table_name='{db_table}')\n"
                     try:
                         with open(dest_file, 'a') as f: #exists, overwrite, append?
                             f.write(plot_script_src)
@@ -494,7 +494,7 @@ class Plugin_Manager():
                     plot_script_src += f"from {import_str}.test import Test\n"
                     plot_script_src += f"pm = Plugin_Manager(settings=Project_Settings)\n"
                     plot_script_src += f"pm.add_test(Test)\n"
-                    plot_script_src += f"pm.evaluate(database='data_log.sqlite', table_name='{archived_table_name}')\n"
+                    plot_script_src += f"pm.evaluate(database='data_log.sqlite', table_name='{db_table}')\n"
                     try:
                         with open(dest_file, 'a') as f: #exists, overwrite, append?
                             f.write(plot_script_src)

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -190,6 +190,7 @@ class Plugin_Manager():
             break
         if self.temperature_channel == None:
             self.temperature_channel = self.master.add_channel_dummy("tdegc")
+        if not self._temperatures:
             self.temperature_channel.write(25)
 
     def _add_components(self):


### PR DESCRIPTION
Instead of run() in a suite script, one can instead call display_connections() which will show the connections needed for a compatible suite, or the first conflict found in a problematic one.