### PR TITLE
When provided with a database as a source for plotting, reassigns the…

### DIFF
--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -774,6 +774,8 @@ class Plugin_Manager():
                 if database is None:
                     database = test.get_db_file()
                     reset_db = True
+                else:
+                    test._db_file = database
                 if table_name is None:
                     test._table_name = test.get_name()
                     reset_tn = True


### PR DESCRIPTION
… test script's associated database to that one. (Normally defaults to the database in the test script's scratch folder.)