### PR TITLE
Upgrade GitHub Actions to v4 for Node 20 compatibility

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,14 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
-          # Upload entire repository
           path: './docs/_build/html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Upgrades all GitHub Actions in `static.yml` and `python-publish.yml` to their latest major versions (v4/v5)
- Fixes "Deploy static content to Pages" workflow failure caused by GitHub deprecating the Node 16 runtime used by v2/v3 actions

## Changes
- `actions/checkout` v3 → v4
- `actions/configure-pages` v3 → v4
- `actions/upload-pages-artifact` v2 → v4
- `actions/deploy-pages` v2 → v4
- `actions/setup-python` v3 → v5

## Test plan
- [ ] Merge to main and verify Pages deployment succeeds
- [ ] Verify python-publish workflow still triggers correctly on release

🤖 Generated with [Claude Code](https://claude.com/claude-code)