### PR TITLE
ci: consolidate all lint steps into pylint.yml

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,12 +1,45 @@
-name: Pylint
+name: Lint
 
-on: [push]
+on: [push, pull_request]
 
 permissions:
   contents: read
 
 jobs:
-  build:
+  flake8:
+    name: Flake8 / Doctest coverage (Python 3.10)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.10"
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc pkg-config libcairo2-dev python3-dev libegl1
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+        pip install -e ".[dev]"
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    - name: Lint with flake8 (advisory)
+      run: |
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Check docstring coverage (advisory)
+      run: |
+        flake8 PyICe/ Tests/ --select=D --count --statistics --exit-zero
+    - name: Doctest coverage report (advisory)
+      run: |
+        python Tests/doctest_coverage.py
+
+  pylint:
+    name: Pylint (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,61 +1,14 @@
-# This workflow lints and tests PyICe across multiple Python versions.
+# This workflow tests PyICe across multiple Python versions and platforms.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python application
+name: Tests
 
 on: [push, pull_request]
 
 permissions:
   contents: read
 
-env:
-  ACTIONS_STEP_DEBUG: true
-
 jobs:
-  lint:
-    name: Lint (Python 3.10)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.10"
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gcc pkg-config libcairo2-dev python3-dev libegl1
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip --verbose
-        pip install flake8 pytest --verbose
-        if [ -f requirements.txt ]; then pip install -r requirements.txt --verbose; fi
-        pip install -e ".[dev]" --verbose
-    - name: Debug environment
-      run: |
-        echo "=== Python Version ==="
-        python -c "import sys; print(sys.version)"
-        echo "=== Package Versions ==="
-        python -c "import numpy; print(f'numpy: {numpy.__version__}')" 2>/dev/null || echo "numpy: not available"
-        python -c "import scipy; print(f'scipy: {scipy.__version__}')" 2>/dev/null || echo "scipy: not available"
-        echo "=== All Installed Packages ==="
-        python -m pip list
-        echo "=== Dependency Check ==="
-        python -m pip check
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-    - name: Lint with flake8 (advisory)
-      run: |
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Check docstring coverage (advisory)
-      run: |
-        flake8 PyICe/ Tests/ --select=D --count --statistics --exit-zero
-    - name: Doctest coverage report (advisory)
-      run: |
-        python Tests/doctest_coverage.py
-
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
Move flake8, docstring coverage, and doctest coverage steps from python-app.yml into pylint.yml. Rename the workflow from 'Pylint' to 'Lint' and add pull_request trigger. python-app.yml is now tests-only, renamed to 'Tests'. Debug environment step and ACTIONS_STEP_DEBUG env removed as temporary artifacts.

⚙️ Generated with ChipAgents