### PR TITLE
Switch to git-tag-based versioning via hatch-vcs

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 venv/
 PyICePad/PyICepad++.bat
 env/
+PyICe/_version.py

--- a/PyICe/__init__.py
+++ b/PyICe/__init__.py
@@ -1,2 +1,6 @@
 DEFAULT_AUTHKEY = b'ltc_lab'
-__version__ = "0.0.6"
+
+try:
+    from PyICe._version import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 #requires = ["setuptools>=61.0"]
 #build-backend = "setuptools.build_meta"
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 
@@ -67,7 +67,10 @@ dependencies=[
 
 #dynamic = ["version"]
 [tool.hatch.version]
-path = "PyICe/__init__.py"
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "PyICe/_version.py"
 
 [tool.hatch.build]
 include = [


### PR DESCRIPTION
Replace manual __version__ in PyICe/__init__.py with hatch-vcs plugin that derives the package version from git tags at build time. This eliminates the need to manually update a version string for each release.

- Add hatch-vcs to build-system requires
- Configure [tool.hatch.version] source = "vcs"
- Auto-generate PyICe/_version.py via build hook
- Add fetch-depth: 0 to publish workflow for tag access
- Add _version.py to .gitignore

⚙️ Generated with ChipAgents