### PR TITLE
Recover more gracefully from a channel/delegator read error. Salvage as much read data as possible, expecially for GUI, but also possibly for script logger.

### DIFF
--- a/PyICe/lab_core.py
+++ b/PyICe/lab_core.py
@@ -6749,7 +6749,14 @@ class logger(master):
                 scan_list.remove_channel(channel)
         # remove the excluded items from the scan list
         scan_list.remove_channel_list(exclusions)
-        channel_data = self.master.read_channel_list(scan_list)
+        try:
+            channel_data = self.master.read_channel_list(scan_list)
+        except PartialReadException as e:
+            e.results['rowid'] = None
+            if 'datetime' not in e.results:
+                e.results['datetime'] = datetime.datetime.now(
+                    datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            raise
         # add additional database columns
         channel_data['rowid'] = None
         if 'datetime' not in channel_data:
@@ -6781,7 +6788,12 @@ class logger(master):
         if exclusions is None:
             exclusions = []
         self._backend.check_exception()
-        data = self._fetch_channel_data(exclusions)
+        try:
+            data = self._fetch_channel_data(exclusions)
+        except PartialReadException as e:
+            self._backend.store(e.results)
+            self._previously_logged_data = e.results
+            raise
         self._backend.store(data)
         self._previously_logged_data = data
         for (key, value) in data.items():
@@ -6867,7 +6879,12 @@ class logger(master):
         if compare_exclusions is None:
             compare_exclusions = []
         self._backend.check_exception()
-        data = self._fetch_channel_data(log_exclusions)
+        try:
+            data = self._fetch_channel_data(log_exclusions)
+        except PartialReadException as e:
+            self._backend.store(e.results)
+            self._previously_logged_data = e.results
+            raise
         if self.check_data_changed(data, compare_exclusions):
             self._backend.store(data)
             self._previously_logged_data = data

--- a/PyICe/lab_core.py
+++ b/PyICe/lab_core.py
@@ -1973,6 +1973,11 @@ class ChannelReadException(ChannelException):
     PyICe.lab_core.ChannelReadException: read failed
     """
 
+    def __init__(self, message, original_exception=None, original_traceback=None):
+        super().__init__(message)
+        self.original_exception = original_exception
+        self.original_traceback = original_traceback
+
     def __eq__(self, other):
         """Check equality.
         Enables equality comparison with ``==``.
@@ -2015,6 +2020,31 @@ class ChannelReadException(ChannelException):
             True if the comparison holds, False otherwise.
         """
         return not self.__eq__(other)
+
+
+class PartialReadException(Exception):
+    """Raised when some channels failed to read but others succeeded.
+
+    Carries partial results so callers (e.g. the GUI) can recover good data
+    while still propagating a failure to scripted sessions.
+
+    >>> from PyICe.lab_core import PartialReadException, ChannelReadException
+    >>> cre = ChannelReadException('READ_ERROR', original_exception=IOError("timeout"))
+    >>> exc = PartialReadException({'ch': cre}, {'ch': cre})
+    >>> 'ch' in exc.failures
+    True
+    """
+
+    def __init__(self, results, failures):
+        self.results = results
+        self.failures = failures
+        causes = set()
+        for cre in failures.values():
+            if cre.original_exception:
+                causes.add(f"{type(cre.original_exception).__name__}: {cre.original_exception}")
+        msg = (f"{len(failures)} channel(s) failed to read: "
+               + "; ".join(causes) if causes else f"{len(failures)} channel(s) failed to read")
+        super().__init__(msg)
 
 
 class RemoteChannelGroupException(ChannelException):
@@ -4017,6 +4047,10 @@ class channel_group(object):
                     self._self_delegation_channels))
         self._partial_delegation_results = results_ord_dict()
         self._self_delegation_channels = results_ord_dict()
+        failures = {name: val for name, val in results.items()
+                    if isinstance(val, ChannelReadException)}
+        if failures:
+            raise PartialReadException(results, failures)
         return results
 
     def _read_channels_non_threaded(self, channel_list):
@@ -4034,8 +4068,15 @@ class channel_group(object):
             for channel in channel_list:
                 if delegator == channel.resolve_delegator():
                     channel_delegation_list.append(channel)
-            results.update(
-                delegator._read_delegated_channel_list(channel_delegation_list))
+            try:
+                results.update(
+                    delegator._read_delegated_channel_list(channel_delegation_list))
+            except Exception as e:
+                tb = traceback.format_exc()
+                debug_logging.error(f"Delegator read failed: {e}\n{tb}")
+                for channel in channel_delegation_list:
+                    results[channel.get_name()] = ChannelReadException(
+                        'READ_ERROR', original_exception=e, original_traceback=tb)
         return results
 
     def _read_channels_threaded(self, channel_list):

--- a/PyICe/lab_core.py
+++ b/PyICe/lab_core.py
@@ -1971,6 +1971,17 @@ class ChannelReadException(ChannelException):
     Traceback (most recent call last):
         ...
     PyICe.lab_core.ChannelReadException: read failed
+    >>> cre = ChannelReadException('TIMEOUT', original_exception=IOError("bus hung"))
+    >>> cre.original_exception
+    OSError('bus hung')
+    >>> cre.original_traceback is None
+    True
+    >>> str(cre)
+    'TIMEOUT'
+    >>> ChannelReadException('A') == ChannelReadException('A')
+    True
+    >>> ChannelReadException('A') == ChannelReadException('B')
+    False
     """
 
     def __init__(self, message, original_exception=None, original_traceback=None):
@@ -2030,8 +2041,14 @@ class PartialReadException(Exception):
 
     >>> from PyICe.lab_core import PartialReadException, ChannelReadException
     >>> cre = ChannelReadException('READ_ERROR', original_exception=IOError("timeout"))
-    >>> exc = PartialReadException({'ch': cre}, {'ch': cre})
+    >>> exc = PartialReadException({'ok': 3.14, 'ch': cre}, {'ch': cre})
+    >>> exc.results['ok']
+    3.14
     >>> 'ch' in exc.failures
+    True
+    >>> 'ok' not in exc.failures
+    True
+    >>> 'IOError' in str(exc) or 'OSError' in str(exc)
     True
     """
 
@@ -7554,7 +7571,9 @@ class logger_backend(object):
             bytes_coldata = column_data.tobytes()
             return dtype_header + bytes_coldata
         elif isinstance(column_data, ChannelReadException):
-            return None
+            exc_type = type(column_data.original_exception).__name__ if column_data.original_exception else 'Unknown'
+            exc_msg = str(column_data.original_exception) if column_data.original_exception else str(column_data)
+            return f'READ_ERROR:{exc_type}:{exc_msg}'
         elif isinstance(column_data, channel):
             return str(column_data)
         return column_data

--- a/PyICe/lab_gui.py
+++ b/PyICe/lab_gui.py
@@ -4191,11 +4191,18 @@ class background_worker(QtCore.QThread):
             print("background error")
             print(e)
             print(traceback.format_exc())
-            # print "attempting to read individually"
+            print("attempting to read individually")
             results = {}
             for channel in channels:
-                results[channel.get_name()] = lab_core.ChannelReadException(
-                    'READ_ERROR')
+                try:
+                    result = self._channel_group.read_channel_list([channel])
+                    results.update(result)
+                except Exception as e2:
+                    print("individual read error on '{}'".format(channel.get_name()))
+                    print(e2)
+                    print(traceback.format_exc())
+                    results[channel.get_name()] = lab_core.ChannelReadException(
+                        'READ_ERROR')
         return results
 
     def _read_channel_list(self, read_list):

--- a/PyICe/lab_gui.py
+++ b/PyICe/lab_gui.py
@@ -4187,22 +4187,17 @@ class background_worker(QtCore.QThread):
                 channels.append(self._channel_group[name])
         try:
             results = self._channel_group.read_channel_list(channels)
+        except lab_core.PartialReadException as e:
+            print("Partial read failure: {}".format(e))
+            results = e.results
         except Exception as e:
             print("background error")
             print(e)
             print(traceback.format_exc())
-            print("attempting to read individually")
             results = {}
             for channel in channels:
-                try:
-                    result = self._channel_group.read_channel_list([channel])
-                    results.update(result)
-                except Exception as e2:
-                    print("individual read error on '{}'".format(channel.get_name()))
-                    print(e2)
-                    print(traceback.format_exc())
-                    results[channel.get_name()] = lab_core.ChannelReadException(
-                        'READ_ERROR')
+                results[channel.get_name()] = lab_core.ChannelReadException(
+                    'READ_ERROR')
         return results
 
     def _read_channel_list(self, read_list):

--- a/PyICe/lab_utils/sqlite_data.py
+++ b/PyICe/lab_utils/sqlite_data.py
@@ -13,6 +13,17 @@ import collections
 from .time_zones import UTC
 from .str2num import str2num
 
+ChannelFailure = collections.namedtuple('ChannelFailure', ['exception_type', 'message'])
+"""Structured representation of a channel read failure deserialized from the database.
+
+>>> from PyICe.lab_utils.sqlite_data import ChannelFailure
+>>> cf = ChannelFailure(exception_type='RuntimeError', message='bus timeout')
+>>> cf.exception_type
+'RuntimeError'
+>>> cf.message
+'bus timeout'
+"""
+
 
 class sqlite_data(
         collections.abc.Sequence):  # collections.Iterable to disable slicing?
@@ -154,6 +165,8 @@ class sqlite_data(
         {'a': 1}
         >>> sqlite_data.convert_vector(b"(4, 5)")
         (4, 5)
+        >>> sqlite_data.convert_vector(b"READ_ERROR:RuntimeError:bus timeout")
+        ChannelFailure(exception_type='RuntimeError', message='bus timeout')
 
         Args:
             col_data_bytes: Raw bytes read from a NUMERIC, PyICeDict,
@@ -165,7 +178,12 @@ class sqlite_data(
             numeric conversion fails.
         """
         col_data_str = col_data_bytes.decode('utf-8')
-        if re.match(r'^\[.*\]$', col_data_str):
+        if col_data_str.startswith('READ_ERROR:'):
+            parts = col_data_str.split(':', 2)
+            exc_type = parts[1] if len(parts) > 1 else 'Unknown'
+            exc_msg = parts[2] if len(parts) > 2 else ''
+            return ChannelFailure(exception_type=exc_type, message=exc_msg)
+        elif re.match(r'^\[.*\]$', col_data_str):
             return ast.literal_eval(col_data_str)  # This is slow!
         elif re.match(r'^\{.*\}$', col_data_str):
             return ast.literal_eval(col_data_str)

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -25,7 +25,7 @@ from PyICe.lab_utils.timed_response import timed_input
 from PyICe.lab_utils.communications import email, sms
 from PyICe.lab_utils.sqlite_data import sqlite_data
 from PyICe.lab_utils.banners import print_banner
-from PyICe.lab_core import logger, master
+from PyICe.lab_core import logger, master, PartialReadException, ChannelReadException
 from PyICe.plugins import test_archive
 from email.mime.image import MIMEImage
 from PyICe import LTC_plot
@@ -833,13 +833,28 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
                     crash_log['last_logged_row'] = f'ERROR: {row_exc}'
             # Live re-read of every channel — represents current instrument state but may
             # block or fail if a device is wedged. Errors are recorded per-channel.
+            # If the crash was caused by a PartialReadException, reuse its successful
+            # results and only re-read the channels that failed.
             live_readings = {}
             if hasattr(test, '_logger'):
+                partial_results = None
+                if isinstance(value, PartialReadException):
+                    partial_results = value.results
                 for channel in test._logger.get_all_channel_names():
-                    try:
-                        live_readings[channel] = test._logger.read(channel)
-                    except Exception as read_exc:
-                        live_readings[channel] = f'READ ERROR: {read_exc}'
+                    if partial_results is not None and channel in partial_results:
+                        ch_val = partial_results[channel]
+                        if isinstance(ch_val, ChannelReadException):
+                            try:
+                                live_readings[channel] = test._logger.read(channel)
+                            except Exception as read_exc:
+                                live_readings[channel] = f'READ ERROR: {read_exc}'
+                        else:
+                            live_readings[channel] = ch_val
+                    else:
+                        try:
+                            live_readings[channel] = test._logger.read(channel)
+                        except Exception as read_exc:
+                            live_readings[channel] = f'READ ERROR: {read_exc}'
             crash_log['live_channel_readings'] = live_readings
             test._crash_logs[file_name] = crash_log
             try:

--- a/Tests/test_channel_master.py
+++ b/Tests/test_channel_master.py
@@ -342,6 +342,7 @@ class TestChannelMasterThreading:
         Args:
             master_instance: Master instance.
         """
+        from PyICe.lab_core import PartialReadException, ChannelReadException
         m = master_instance
 
         def bad_read():
@@ -353,8 +354,14 @@ class TestChannelMasterThreading:
             raise ValueError("simulated failure")
 
         m.add_channel_virtual('bad', read_function=bad_read)
-        with pytest.raises(ValueError, match="simulated failure"):
+        with pytest.raises(PartialReadException) as exc_info:
             m.read_all_channels()
+        exc = exc_info.value
+        assert 'bad' in exc.failures
+        assert isinstance(exc.failures['bad'], ChannelReadException)
+        assert isinstance(exc.failures['bad'].original_exception, ValueError)
+        assert "simulated failure" in str(exc.failures['bad'].original_exception)
+        assert exc.failures['bad'].original_traceback is not None
 
 
 class TestMaster:

--- a/Tests/test_logger_unit.py
+++ b/Tests/test_logger_unit.py
@@ -2,7 +2,7 @@
 import os
 import sqlite3
 import pytest
-from PyICe.lab_core import logger, master
+from PyICe.lab_core import logger, master, PartialReadException, ChannelReadException
 
 
 @pytest.fixture
@@ -314,3 +314,111 @@ class TestLoggerDataChannels:
         conn.close()
         assert count == 10
         lg.stop()
+
+@pytest.mark.database
+class TestLoggerPartialRead:
+    """Tests that logger stores partial results before re-raising PartialReadException."""
+
+    @pytest.fixture
+    def partial_logger(self, tmp_path):
+        """Logger with one good and one failing channel.
+
+        Args:
+            tmp_path: Tmp path.
+
+        Yields:
+            Next value.
+        """
+        m = master()
+        m.add_channel_dummy('good_ch').write(42.0)
+        m.add_channel_virtual('bad_ch',
+                              read_function=lambda: (_ for _ in ()).throw(
+                                  RuntimeError("comm failure")))
+        db_path = str(tmp_path / "partial.sqlite")
+        lg = logger(m, database=db_path, use_threads=False)
+        lg.new_table('test_partial', replace_table=True)
+        yield lg, db_path, m
+        lg.stop()
+        m.stop_threads()
+
+    def test_log_stores_partial_row_before_raising(self, partial_logger):
+        """logger.log() commits partial results to DB then raises PartialReadException."""
+        lg, db_path, m = partial_logger
+        with pytest.raises(PartialReadException):
+            lg.log()
+        conn = sqlite3.connect(db_path)
+        row = conn.execute("SELECT good_ch, bad_ch FROM test_partial").fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == 42.0
+        assert row[1].startswith('READ_ERROR:RuntimeError:comm failure')
+
+    def test_log_partial_row_has_datetime(self, partial_logger):
+        """Partial row includes datetime metadata column."""
+        lg, db_path, m = partial_logger
+        with pytest.raises(PartialReadException):
+            lg.log()
+        conn = sqlite3.connect(db_path)
+        row = conn.execute("SELECT datetime FROM test_partial").fetchone()
+        conn.close()
+        assert row[0] is not None
+        assert 'T' in row[0]
+
+    def test_log_updates_previously_logged_data(self, partial_logger):
+        """_previously_logged_data is set even on partial failure."""
+        lg, db_path, m = partial_logger
+        with pytest.raises(PartialReadException):
+            lg.log()
+        assert lg._previously_logged_data is not None
+        assert lg._previously_logged_data['good_ch'] == 42.0
+        assert isinstance(lg._previously_logged_data['bad_ch'], ChannelReadException)
+
+    def test_log_if_changed_stores_partial_row(self, partial_logger):
+        """log_if_changed() also commits partial results before raising."""
+        lg, db_path, m = partial_logger
+        with pytest.raises(PartialReadException):
+            lg.log_if_changed()
+        conn = sqlite3.connect(db_path)
+        row = conn.execute("SELECT good_ch, bad_ch FROM test_partial").fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == 42.0
+
+    def test_exception_carries_enriched_results(self, partial_logger):
+        """PartialReadException.results includes rowid and datetime."""
+        lg, db_path, m = partial_logger
+        with pytest.raises(PartialReadException) as exc_info:
+            lg.log()
+        results = exc_info.value.results
+        assert 'rowid' in results
+        assert 'datetime' in results
+        assert results['good_ch'] == 42.0
+
+    def test_all_good_channels_no_exception(self, tmp_path):
+        """No PartialReadException when all channels succeed."""
+        m = master()
+        m.add_channel_dummy('a').write(1.0)
+        m.add_channel_dummy('b').write(2.0)
+        db_path = str(tmp_path / "allgood.sqlite")
+        lg = logger(m, database=db_path, use_threads=False)
+        lg.new_table('t', replace_table=True)
+        data = lg.log()
+        assert data['a'] == 1.0
+        assert data['b'] == 2.0
+        lg.stop()
+        m.stop_threads()
+
+    def test_sqlite_data_deserializes_channel_failure(self, partial_logger):
+        """sqlite_data returns ChannelFailure namedtuple for failed channels."""
+        from PyICe.lab_utils.sqlite_data import sqlite_data, ChannelFailure
+        lg, db_path, m = partial_logger
+        with pytest.raises(PartialReadException):
+            lg.log()
+        lg.stop()
+        sd = sqlite_data(table_name='test_partial', database_file=db_path)
+        row = sd[0]
+        assert row['good_ch'] == 42.0
+        failure = row['bad_ch']
+        assert isinstance(failure, ChannelFailure)
+        assert failure.exception_type == 'RuntimeError'
+        assert failure.message == 'comm failure'

--- a/Tests/test_partial_read.py
+++ b/Tests/test_partial_read.py
@@ -1,7 +1,7 @@
 """Tests for PartialReadException and per-delegator read isolation."""
 import pytest
 from PyICe.lab_core import (ChannelReadException, PartialReadException,
-                            results_ord_dict, channel_group, delegator)
+                            channel_group, delegator)
 
 
 class TestChannelReadException:

--- a/Tests/test_partial_read.py
+++ b/Tests/test_partial_read.py
@@ -1,0 +1,170 @@
+"""Tests for PartialReadException and per-delegator read isolation."""
+import pytest
+from unittest.mock import patch, MagicMock
+from PyICe.lab_core import (master, ChannelReadException, PartialReadException,
+                            results_ord_dict, channel_group, delegator)
+
+
+class TestChannelReadException:
+    """Tests for enriched ChannelReadException."""
+
+    def test_stores_original_exception(self):
+        """ChannelReadException preserves the original cause."""
+        orig = ValueError("bad value")
+        cre = ChannelReadException('READ_ERROR', original_exception=orig,
+                                   original_traceback="tb line 1\ntb line 2")
+        assert cre.original_exception is orig
+        assert "tb line 1" in cre.original_traceback
+
+    def test_backward_compat_no_kwargs(self):
+        """ChannelReadException works with just a message."""
+        cre = ChannelReadException('READ_ERROR')
+        assert cre.original_exception is None
+        assert cre.original_traceback is None
+        assert str(cre) == 'READ_ERROR'
+
+    def test_equality_still_works(self):
+        """Equality comparison is unaffected by new fields."""
+        a = ChannelReadException('READ_ERROR')
+        b = ChannelReadException('READ_ERROR', original_exception=RuntimeError("x"))
+        assert a == b
+
+    def test_inequality_with_different_message(self):
+        """Different messages are not equal."""
+        a = ChannelReadException('READ_ERROR')
+        b = ChannelReadException('TIMEOUT')
+        assert a != b
+
+
+class TestPartialReadException:
+    """Tests for PartialReadException structure and message."""
+
+    def test_contains_results_and_failures(self):
+        """PartialReadException carries full results and failure subset."""
+        results = {'ch_ok': 3.14, 'ch_bad': ChannelReadException('READ_ERROR')}
+        failures = {'ch_bad': results['ch_bad']}
+        exc = PartialReadException(results, failures)
+        assert exc.results is results
+        assert exc.failures is failures
+
+    def test_message_includes_cause(self):
+        """Exception message names the original cause."""
+        orig = IOError("device timeout")
+        cre = ChannelReadException('READ_ERROR', original_exception=orig)
+        exc = PartialReadException({'ch': cre}, {'ch': cre})
+        assert "IOError" in str(exc) or "OSError" in str(exc)
+        assert "device timeout" in str(exc)
+
+    def test_message_without_cause(self):
+        """Exception message works when no original_exception set."""
+        cre = ChannelReadException('READ_ERROR')
+        exc = PartialReadException({'ch': cre}, {'ch': cre})
+        assert "1 channel(s) failed" in str(exc)
+
+
+class TestPartialReadInMaster:
+    """Integration tests using master with virtual channels."""
+
+    def test_all_channels_succeed(self, master_instance):
+        """No exception when all reads succeed.
+
+        Args:
+            master_instance: Master instance.
+        """
+        m = master_instance
+        m.add_channel_virtual('a', read_function=lambda: 1.0)
+        m.add_channel_virtual('b', read_function=lambda: 2.0)
+        results = m.read_channel_list([m['a'], m['b']])
+        assert results['a'] == 1.0
+        assert results['b'] == 2.0
+
+    def test_failing_channel_raises_partial(self, master_instance):
+        """A failing read_function raises PartialReadException.
+
+        Args:
+            master_instance: Master instance.
+        """
+        m = master_instance
+
+        def bad_read():
+            raise RuntimeError("instrument disconnected")
+
+        m.add_channel_virtual('good', read_function=lambda: 42)
+        m.add_channel_virtual('bad', read_function=bad_read)
+        with pytest.raises(PartialReadException) as exc_info:
+            m.read_channel_list([m['good'], m['bad']])
+        exc = exc_info.value
+        assert 'bad' in exc.failures
+        assert isinstance(exc.results['bad'], ChannelReadException)
+        assert exc.results['bad'].original_exception is not None
+        assert "instrument disconnected" in str(exc.results['bad'].original_exception)
+
+    def test_gui_pattern_catches_partial(self, master_instance):
+        """GUI-style code recovers partial results from exception.
+
+        Args:
+            master_instance: Master instance.
+        """
+        m = master_instance
+        m.add_channel_virtual('ok_ch', read_function=lambda: 99)
+        m.add_channel_virtual('err_ch', read_function=lambda: (_ for _ in ()).throw(IOError("timeout")))
+        try:
+            results = m.read_channel_list([m['ok_ch'], m['err_ch']])
+        except PartialReadException as e:
+            results = e.results
+        assert results['ok_ch'] == 99
+        assert isinstance(results['err_ch'], ChannelReadException)
+
+    def test_scripted_pattern_crashes(self, master_instance):
+        """Scripted sessions crash with PartialReadException if uncaught.
+
+        Args:
+            master_instance: Master instance.
+        """
+        m = master_instance
+        m.add_channel_virtual('x', read_function=lambda: (_ for _ in ()).throw(ValueError("oops")))
+        with pytest.raises(PartialReadException):
+            m.read_channel_list([m['x']])
+
+
+class TestPerDelegatorIsolation:
+    """Tests that failures in one delegator don't affect another."""
+
+    def test_two_delegators_one_fails(self, master_instance):
+        """Channels on a healthy delegator are preserved when another fails.
+
+        Args:
+            master_instance: Master instance.
+        """
+        m = master_instance
+        m.add_channel_dummy('healthy_ch').write(7.5)
+        m.add_channel_virtual('broken_ch',
+                              read_function=lambda: (_ for _ in ()).throw(
+                                  RuntimeError("bus error")))
+        with pytest.raises(PartialReadException) as exc_info:
+            m.read_channel_list([m['healthy_ch'], m['broken_ch']])
+        exc = exc_info.value
+        assert exc.results['healthy_ch'] == 7.5
+        assert isinstance(exc.results['broken_ch'], ChannelReadException)
+        assert 'broken_ch' in exc.failures
+        assert 'healthy_ch' not in exc.failures
+
+    def test_multiple_good_channels_preserved(self, master_instance):
+        """Many good channels survive a single bad one.
+
+        Args:
+            master_instance: Master instance.
+        """
+        m = master_instance
+        for i in range(5):
+            m.add_channel_dummy(f'ok_{i}').write(i * 10)
+        m.add_channel_virtual('fail',
+                              read_function=lambda: (_ for _ in ()).throw(
+                                  OSError("gone")))
+        channels = [m[f'ok_{i}'] for i in range(5)] + [m['fail']]
+        with pytest.raises(PartialReadException) as exc_info:
+            m.read_channel_list(channels)
+        exc = exc_info.value
+        for i in range(5):
+            assert exc.results[f'ok_{i}'] == i * 10
+        assert isinstance(exc.results['fail'], ChannelReadException)

--- a/Tests/test_partial_read.py
+++ b/Tests/test_partial_read.py
@@ -1,7 +1,6 @@
 """Tests for PartialReadException and per-delegator read isolation."""
 import pytest
-from PyICe.lab_core import (ChannelReadException, PartialReadException,
-                            delegator)
+from PyICe.lab_core import (ChannelReadException, PartialReadException)
 
 
 class TestChannelReadException:

--- a/Tests/test_partial_read.py
+++ b/Tests/test_partial_read.py
@@ -1,6 +1,5 @@
 """Tests for PartialReadException and per-delegator read isolation."""
 import pytest
-from unittest.mock import MagicMock
 from PyICe.lab_core import (ChannelReadException, PartialReadException,
                             results_ord_dict, channel_group, delegator)
 

--- a/Tests/test_partial_read.py
+++ b/Tests/test_partial_read.py
@@ -1,7 +1,7 @@
 """Tests for PartialReadException and per-delegator read isolation."""
 import pytest
 from PyICe.lab_core import (ChannelReadException, PartialReadException,
-                            channel_group, delegator)
+                            delegator)
 
 
 class TestChannelReadException:

--- a/Tests/test_partial_read.py
+++ b/Tests/test_partial_read.py
@@ -1,7 +1,7 @@
 """Tests for PartialReadException and per-delegator read isolation."""
 import pytest
-from unittest.mock import patch, MagicMock
-from PyICe.lab_core import (master, ChannelReadException, PartialReadException,
+from unittest.mock import MagicMock
+from PyICe.lab_core import (ChannelReadException, PartialReadException,
                             results_ord_dict, channel_group, delegator)
 
 


### PR DESCRIPTION
…the uncooperative ones.