### PR TITLE
feat(LTC_plot): add Page.add_comment() for SVG XML comment metadata

### DIFF
--- a/PyICe/LTC_plot.py
+++ b/PyICe/LTC_plot.py
@@ -1292,6 +1292,7 @@ class Page():
         self.plot_list = []
         self.page_type = None
         self.next_position = 0
+        self._svg_comments = []
         matplotlib.rcParams['axes.linewidth'] = 0.6
         matplotlib.rcParams['font.family'] = 'Arial'  # 'Linear Helv Cond'
         # 'Linear Helv Cond'
@@ -1327,6 +1328,14 @@ class Page():
             return str(int(x))
         else:
             return str(x)
+
+    def add_comment(self, text):
+        """Add an XML comment to be embedded in the SVG output.
+
+        Args:
+            text: String content to include in an XML comment.
+        """
+        self._svg_comments.append(str(text).replace("--", "‐‐"))
 
     def add_plot(self, plot,
                  position=None,     # This is if there's just one plot.
@@ -2017,6 +2026,10 @@ class Page():
                                                                       "font-size:9.5px;font-weight:bold").replace("font-size:8.14285714286px;font-style:bold",
                                                                                                                   "font-size:8.14285714286px;font-weight:bold").replace("font-size:9.5px;font-style:bold",
                                                                                                                                                                         "font-size:9.5px;font-weight:bold").encode("utf-8")
+        if self._svg_comments:
+            comment_block = b"\n".join(
+                b"<!-- " + c.encode("utf-8") + b" -->" for c in self._svg_comments)
+            output = output.replace(b"<svg ", comment_block + b"\n<svg ", 1)
         if file_basename is not None:
             filepath = './plots/' if filepath is None else os.path.join(
                 filepath, 'plots')


### PR DESCRIPTION
## Summary

Add a `Page.add_comment(text)` method to `LTC_plot` that embeds arbitrary metadata as XML comments in SVG output. This enables downstream projects to store DUT traceability information (serial number, revid, die variant) as machine-readable metadata inside SVG files, rather than as visible plot annotations.

## Motivation

Projects like `morpheus_eval` currently pass traceability strings (DUT serial number, silicon revision) into `plot_name`, which renders as a small text subscript in the bottom-right corner of every plot. This is fine for informal use but:

- Clutters the visual presentation
- Is not machine-parseable for automated downstream tooling
- Cannot be toggled on/off per-plot without code changes to LTC_plot itself

With this change, callers can choose on a case-by-case basis whether to display traceability visually (`plot_name="DUT:..."`) or embed it invisibly (`plot_name=""` + `page.add_comment("DUT:...")`).

## Changes

| File | Change |
|------|--------|
| `PyICe/LTC_plot.py` | Add `self._svg_comments = []` to `Page.__init__` |
| `PyICe/LTC_plot.py` | Add `Page.add_comment(text)` method with `--` sanitization |
| `PyICe/LTC_plot.py` | Inject queued comments before `<svg` tag in `Page.create_svg()` |

## Usage

```python
G0 = LTC_plot.plot(plot_title="My Plot", plot_name="", ...)
page = LTC_plot.Page(plot_count=1)
page.add_plot(G0)
page.add_comment(f"DUT:{serial_number} REVID:{revid}")
page.create_svg("output_name", filepath="./results")
```

Resulting SVG contains:
```xml
<!-- DUT:ABC123 REVID:A1 -->
<svg ...>
```

## Safety

- Input is sanitized: `--` is replaced with unicode hyphens (`‐‐`) to prevent malformed XML comments per the XML spec.
- No behavioral change for existing callers — `_svg_comments` defaults to an empty list, so `create_svg()` output is identical if `add_comment()` is never called.

⚙️ Generated with ChipAgents
Co-Authored-By: ChipAgents <noreply@chipagents.ai>