### PR TITLE
ci: add timeout to apt install step to prevent 6h hangs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install system dependencies
+      timeout-minutes: 5
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc pkg-config libcairo2-dev python3-dev libegl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev


### PR DESCRIPTION
When GitHub's Azure apt mirror becomes unresponsive, `apt-get update` blocks indefinitely, consuming CI minutes until the 6-hour job limit. This happened in [run 27775620646](https://github.com/PyICe-ADI/PyICe/actions/runs/27775620646), wasting ~18 hours of CI minutes.

Adds a 5-minute `timeout-minutes` to the "Install system dependencies" step so it fails fast and can be retried.

⚙️ Generated with ChipAgents
Co-Authored-By: ChipAgents <noreply@chipagents.ai>