### PR TITLE
ci: migrate PyPI publishing to trusted publisher (OIDC)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,11 +1,3 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Upload Python Package
 
 on:
@@ -14,14 +6,14 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
+    environment: pypi
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: Set up Python
@@ -36,6 +28,3 @@ jobs:
       run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Replace secret-based token authentication with OpenID Connect trusted publishing. This removes dependency on an individual's API token and provides better auditability on PyPI.

## Before merging

1. Configure a trusted publisher on PyPI for `pyice-adi`:
   - Go to https://pypi.org/manage/project/pyice-adi/settings/publishing/
   - Add trusted publisher:
     - Owner: `PyICe-ADI`
     - Repository: `PyICe`
     - Workflow name: `python-publish.yml`
     - Environment: `pypi`
2. Create a `pypi` environment in the repo (Settings > Environments)

## After merging

- Delete the `PYPI_API_TOKEN` repo secret

---
Generated with ChipAgents
Co-Authored-By: ChipAgents <noreply@chipagents.ai>