### PR TITLE
docs: Fix stale emails, update git workflow, improve correlate_data docstring

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,10 @@ for a handy cheatsheet on how to use git.  If you find yourself in a pickle,
 there is also [oh s***, git!](https://ohshitgit.com/), which has a several ways to
 clean up a Git disaster.
 
-When you beging working on a feature, please branch off of the master branch
+When you begin working on a feature, please branch off of the main branch
 ```commandline
-git checkout master
-git branch new_feature_name
+git checkout main
+git checkout -b new_feature_name
 ```
 Make your commits small - that makes it much easier for other contributors to
 see your workflow.

--- a/PyICe/plugins/master_test_template.py
+++ b/PyICe/plugins/master_test_template.py
@@ -538,21 +538,30 @@ class Master_Test_Template():  # pylint: disable=no-member; this is a mixin/temp
 
     def correlate_data(self, name, reference_values=None,
                        test_values=None, spec=None, conditions=None):
-        """Compare test values to reference values and evaluate against named test limits.
+        """Compare measured test values against reference values and evaluate against test limits.
 
-        Supports the ``Master_Test_Template`` workflow by performing the described operation.
-
+        Computes the deviation between each pair of (reference, test) values
+        using the mode specified by ``spec``, then checks whether the deviation
+        falls within the named test's limits (as returned by ``get_test_limits(name)``).
 
         >>> from PyICe.plugins.master_test_template import Master_Test_Template
         >>> hasattr(Master_Test_Template, 'correlate_data')
         True
 
         Args:
-            name: The name of the test whose limits will be used.
-            reference_values: Base values to compare against.
-            test_values: Values whose distance to reference will be calculated.
-            spec: Either '%' for percentage or '-' for difference comparison.
-            conditions: Dictionary of channel names to values for reporting context, or None.
+            name: Key into the test limits table (from ``get_test_limits``).
+                Identifies which min/max limits to evaluate against.
+            reference_values: Golden/expected values, typically from
+                characterization data or a datasheet. List of numeric values.
+            test_values: Measured values from the current test run. Must be
+                the same length as reference_values.
+            spec: Comparison mode. ``'%'`` computes percentage deviation
+                ``(test - ref) / ref * 100``; ``'-'`` computes absolute
+                difference ``test - ref``.
+            conditions: Optional dict of {channel_name: value} pairs
+                describing the operating conditions (e.g. temperature, supply
+                voltage) under which the measurement was taken. Used for
+                reporting context only.
         """
         if reference_values is None:
             reference_values = []

--- a/PyICe/sphinx-doc/source/PyICe.rst
+++ b/PyICe/sphinx-doc/source/PyICe.rst
@@ -46,10 +46,10 @@ and a brief overview of the basic capabilities and usage here:
 
 The PyICe library is relatively stable but is under ongoing development.
 
-A working copy can be checked out from the Boston SVN server (linux credentials required) here:
+The source code is hosted on GitHub:
 ::
 
-  http://bos-svn.engineering.linear.com/svn/PyICe/trunk/
+  https://github.com/PyICe-ADI/PyICe
 
 
 .. autosummary::
@@ -71,12 +71,10 @@ A working copy can be checked out from the Boston SVN server (linux credentials 
 Documentation is a work in progress.
 
 Please contact us with any questions, requests for documentation, or to volunteer help developing additional instrument drivers:
-  - Steve Martin
-    smartin@linear.com
-  - Dave Simmons
-    dsimmons@linear.com
-  - Zach Lewko
-    zlewko@linear.com
+  - Mailing list: pyice-developers@analog.com
+  - Steve Martin: xenomorphxx131@gmail.com
+  - Dave Simmons: david.simmons@analog.com
+  - Zach Lewko: zachary.lewko@analog.com
 
 
 


### PR DESCRIPTION
## Summary

Fixes stale documentation across the project (emails, URLs, git workflow) and improves the `correlate_data()` docstring per user feedback.

## Changes

- **Sphinx docs:** Replace `linear.com` emails with current addresses, update SVN URL → GitHub, add `pyice-developers@analog.com` mailing list
- **CONTRIBUTING.md:** Fix `master` → `main`, fix `git branch` → `git checkout -b`
- **`correlate_data()` docstring:** Expanded argument descriptions with types, semantics, and comparison mode explanations

Closes #194
Closes #148

---
⚙️ Generated with ChipAgents
Co-Authored-By: ChipAgents <noreply@chipagents.ai>