### PR TITLE
Crash log on debug

### DIFF
--- a/PyICe/lab_utils/json_encoder.py
+++ b/PyICe/lab_utils/json_encoder.py
@@ -1,0 +1,49 @@
+"""Shared JSON encoder for PyICe data types.
+
+>>> from PyICe.lab_utils.json_encoder import PyICeJSONEncoder
+>>> import json, numpy as np, datetime
+>>> json.dumps(np.array([1.0, 2.0]), cls=PyICeJSONEncoder)
+'[1.0, 2.0]'
+>>> json.dumps(np.bool_(True), cls=PyICeJSONEncoder)
+'true'
+>>> json.dumps(datetime.datetime(2024, 1, 1, 12, 0), cls=PyICeJSONEncoder)
+'"2024-01-01T12:00:00.000000Z"'
+"""
+import json
+import datetime
+import numpy as np
+
+
+class PyICeJSONEncoder(json.JSONEncoder):
+    """JSON encoder that handles numpy types, datetimes, and bytes.
+
+    Falls back to repr() for any unrecognized type, ensuring serialization
+    never raises.
+
+    >>> from PyICe.lab_utils.json_encoder import PyICeJSONEncoder
+    >>> PyICeJSONEncoder is not None
+    True
+    """
+
+    def default(self, obj):
+        """Serialize obj to a JSON-compatible type.
+
+        >>> from PyICe.lab_utils.json_encoder import PyICeJSONEncoder
+        >>> hasattr(PyICeJSONEncoder, 'default')
+        True
+        """
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, np.bool_):
+            return bool(obj)
+        if isinstance(obj, np.integer):
+            return int(obj)
+        if isinstance(obj, np.floating):
+            return float(obj)
+        if isinstance(obj, datetime.datetime):
+            return obj.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        if isinstance(obj, datetime.timedelta):
+            return obj.total_seconds()
+        if isinstance(obj, bytes):
+            return repr(obj)
+        return repr(obj)

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -93,6 +93,28 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
     """
     _CRASH_LOG_MAX_CHAIN_DEPTH = 10
 
+    class _CrashLogJSONEncoder(json.JSONEncoder):
+        """JSON encoder for crash logs, matching the serialization used by test_results."""
+
+        def default(self, obj):
+            """Serialize numpy arrays, datetimes, and numpy bools; fall back to repr."""
+            import numpy as np
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+            if isinstance(obj, np.bool_):
+                return bool(obj)
+            if isinstance(obj, np.integer):
+                return int(obj)
+            if isinstance(obj, np.floating):
+                return float(obj)
+            if isinstance(obj, datetime.datetime):
+                return obj.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            if isinstance(obj, datetime.timedelta):
+                return obj.total_seconds()
+            if isinstance(obj, bytes):
+                return repr(obj)
+            return repr(obj)
+
     def __init__(self, scratch_folder='scratch', settings={}):
         """Initialize plugin_ manager.
         Initializes 8 instance attributes that configure the object's
@@ -864,14 +886,14 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
             try:
                 scratch_path = os.path.join(test._module_path, self.scratch_folder, f'{file_name}.json')
                 with open(scratch_path, 'w') as f:
-                    json.dump(crash_log, f, indent=2, default=repr)
+                    json.dump(crash_log, f, indent=2, cls=self._CrashLogJSONEncoder)
             except Exception as write_exc:
                 print_banner(f'WARNING: Failed to write crash_log.json: {write_exc}')
         except Exception as build_exc:
             print_banner(f'WARNING: Exception while building crash log: {build_exc}')
             traceback.print_exc()
             test._crash_logs[file_name] =  'crash log construction failed before completion'
-        self.notify(json.dumps(crash_log, indent=2), subject=f'{test.get_name()} CRASH LOG')
+        self.notify(json.dumps(crash_log, indent=2, cls=self._CrashLogJSONEncoder), subject=f'{test.get_name()} CRASH LOG')
         return crash_log
 
     ###
@@ -1341,6 +1363,9 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
                             else:
                                 print(f'{test.get_name()} completed in {test_time["test_delta_min"]:.1f} minutes.')
                         except (Exception, BaseException) as e:
+                            from bdb import BdbQuit
+                            if isinstance(e, BdbQuit):
+                                continue
                             traceback.print_exc()
                             test_time = test._test_timer.read_all_channels()
                             test._is_crashed = True

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -1362,7 +1362,7 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
                                 summary_msg+=f"\t{test.get_name()} ran successfully. {test_time['test_delta_min']:.1f} minutes.\n"
                             else:
                                 print(f'{test.get_name()} completed in {test_time["test_delta_min"]:.1f} minutes.')
-                        except (Exception, BaseException) as e:
+                        except BaseException as e:
                             from bdb import BdbQuit
                             # Python 3.14: pdb's do_quit calls sys.exit(1) instead of raising BdbQuit
                             if isinstance(e, BdbQuit) or (isinstance(e, SystemExit) and 'pdb.py' in traceback.format_exc()):

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -1423,7 +1423,6 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
             if isinstance(e, BdbQuit) or (isinstance(e, SystemExit) and 'pdb.py' in traceback.format_exc()):
                 print_banner('Debugger quit. Ending run.')
                 self.shutdown()
-                self.close_ports()
                 return
             traceback.print_exc()
             for test in self.tests:

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -1364,6 +1364,7 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
                                 print(f'{test.get_name()} completed in {test_time["test_delta_min"]:.1f} minutes.')
                         except (Exception, BaseException) as e:
                             from bdb import BdbQuit
+                            # Python 3.14: pdb's do_quit calls sys.exit(1) instead of raising BdbQuit
                             if isinstance(e, BdbQuit) or (isinstance(e, SystemExit) and 'pdb.py' in traceback.format_exc()):
                                 raise
                             traceback.print_exc()
@@ -1420,6 +1421,7 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
             self.shutdown()
         except (Exception, SystemExit) as e:
             from bdb import BdbQuit
+            # Python 3.14: pdb's do_quit calls sys.exit(1) instead of raising BdbQuit
             if isinstance(e, BdbQuit) or (isinstance(e, SystemExit) and 'pdb.py' in traceback.format_exc()):
                 print_banner('Debugger quit. Ending run.')
                 self.shutdown()

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -1365,7 +1365,7 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
                         except (Exception, BaseException) as e:
                             from bdb import BdbQuit
                             if isinstance(e, BdbQuit):
-                                continue
+                                raise
                             traceback.print_exc()
                             test_time = test._test_timer.read_all_channels()
                             test._is_crashed = True
@@ -1418,7 +1418,13 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
             finish_msg = f'All tests completed. Total run time: {run_time_data["run_total_min"]:.1f} minutes.\n'
             self.notify(finish_msg, subject='Collection Complete')
             self.shutdown()
-        except Exception:
+        except Exception as e:
+            from bdb import BdbQuit
+            if isinstance(e, BdbQuit):
+                print_banner('Debugger quit. Ending run.')
+                self.shutdown()
+                self.close_ports()
+                return
             traceback.print_exc()
             for test in self.tests:
                 test._is_crashed = True

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -26,6 +26,7 @@ from PyICe.lab_utils.communications import email, sms
 from PyICe.lab_utils.sqlite_data import sqlite_data
 from PyICe.lab_utils.banners import print_banner
 from PyICe.lab_core import logger, master, PartialReadException, ChannelReadException
+from PyICe.lab_utils.json_encoder import PyICeJSONEncoder
 from PyICe.plugins import test_archive
 from email.mime.image import MIMEImage
 from PyICe import LTC_plot
@@ -92,28 +93,6 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
 
     """
     _CRASH_LOG_MAX_CHAIN_DEPTH = 10
-
-    class _CrashLogJSONEncoder(json.JSONEncoder):
-        """JSON encoder for crash logs, matching the serialization used by test_results."""
-
-        def default(self, obj):
-            """Serialize numpy arrays, datetimes, and numpy bools; fall back to repr."""
-            import numpy as np
-            if isinstance(obj, np.ndarray):
-                return obj.tolist()
-            if isinstance(obj, np.bool_):
-                return bool(obj)
-            if isinstance(obj, np.integer):
-                return int(obj)
-            if isinstance(obj, np.floating):
-                return float(obj)
-            if isinstance(obj, datetime.datetime):
-                return obj.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-            if isinstance(obj, datetime.timedelta):
-                return obj.total_seconds()
-            if isinstance(obj, bytes):
-                return repr(obj)
-            return repr(obj)
 
     def __init__(self, scratch_folder='scratch', settings={}):
         """Initialize plugin_ manager.
@@ -886,14 +865,14 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
             try:
                 scratch_path = os.path.join(test._module_path, self.scratch_folder, f'{file_name}.json')
                 with open(scratch_path, 'w') as f:
-                    json.dump(crash_log, f, indent=2, cls=self._CrashLogJSONEncoder)
+                    json.dump(crash_log, f, indent=2, cls=PyICeJSONEncoder)
             except Exception as write_exc:
                 print_banner(f'WARNING: Failed to write crash_log.json: {write_exc}')
         except Exception as build_exc:
             print_banner(f'WARNING: Exception while building crash log: {build_exc}')
             traceback.print_exc()
             test._crash_logs[file_name] =  'crash log construction failed before completion'
-        self.notify(json.dumps(crash_log, indent=2, cls=self._CrashLogJSONEncoder), subject=f'{test.get_name()} CRASH LOG')
+        self.notify(json.dumps(crash_log, indent=2, cls=PyICeJSONEncoder), subject=f'{test.get_name()} CRASH LOG')
         return crash_log
 
     ###

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -1364,7 +1364,7 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
                                 print(f'{test.get_name()} completed in {test_time["test_delta_min"]:.1f} minutes.')
                         except (Exception, BaseException) as e:
                             from bdb import BdbQuit
-                            if isinstance(e, BdbQuit):
+                            if isinstance(e, BdbQuit) or (isinstance(e, SystemExit) and 'pdb.py' in traceback.format_exc()):
                                 raise
                             traceback.print_exc()
                             test_time = test._test_timer.read_all_channels()
@@ -1418,9 +1418,9 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
             finish_msg = f'All tests completed. Total run time: {run_time_data["run_total_min"]:.1f} minutes.\n'
             self.notify(finish_msg, subject='Collection Complete')
             self.shutdown()
-        except Exception as e:
+        except (Exception, SystemExit) as e:
             from bdb import BdbQuit
-            if isinstance(e, BdbQuit):
+            if isinstance(e, BdbQuit) or (isinstance(e, SystemExit) and 'pdb.py' in traceback.format_exc()):
                 print_banner('Debugger quit. Ending run.')
                 self.shutdown()
                 self.close_ports()

--- a/PyICe/plugins/plugin_manager.py
+++ b/PyICe/plugins/plugin_manager.py
@@ -1341,7 +1341,7 @@ class Plugin_Manager():  # pylint: disable=no-member; attributes (plugins, proje
                                 summary_msg+=f"\t{test.get_name()} ran successfully. {test_time['test_delta_min']:.1f} minutes.\n"
                             else:
                                 print(f'{test.get_name()} completed in {test_time["test_delta_min"]:.1f} minutes.')
-                        except BaseException as e:
+                        except BaseException as e:  # noqa: BLE001 - intentional; handles KeyboardInterrupt and BdbQuit/SystemExit from debugger
                             from bdb import BdbQuit
                             # Python 3.14: pdb's do_quit calls sys.exit(1) instead of raising BdbQuit
                             if isinstance(e, BdbQuit) or (isinstance(e, SystemExit) and 'pdb.py' in traceback.format_exc()):

--- a/PyICe/plugins/test_results.py
+++ b/PyICe/plugins/test_results.py
@@ -12,7 +12,7 @@ import datetime
 import functools
 import json
 import numbers
-from numpy import bool_, ndarray  # pylint: disable=import-error; numpy is a required dependency for this module but may not be installed in all environments
+from PyICe.lab_utils.json_encoder import PyICeJSONEncoder
 
 # https://stackoverflow.com/questions/5884066/hashing-a-dictionary/22003440#22003440
 
@@ -255,42 +255,6 @@ class generic_results():
         if ate_results is None:
             ate_results = []
 
-        class CustomJSONizer(json.JSONEncoder):
-            """Custom j s o nizer (j s o n encoder subclass)."""
-            def default(self, obj):
-                """Return the default.
-
-                Supports the ``CustomJSONizer`` workflow by performing the described operation.
-
-
-                >>> from PyICe.plugins.test_results import generic_results
-                >>> hasattr(generic_results, 'default')
-                True
-
-                Args:
-                    obj: Obj to use.
-
-                Returns:
-                    The default value.
-
-                Raises:
-                    TypeError: If an argument has an incompatible type.
-                """
-                if isinstance(obj, bool_):
-                    return bool(obj)
-                elif isinstance(obj, datetime.datetime):
-                    return obj.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-                elif isinstance(obj, ndarray):
-                    return obj.tolist()
-                else:
-                    try:
-                        return super().default(obj)
-                    except TypeError as e:
-                        print(
-                            f'JSON Serialization error with object of type {type(obj)}:')
-                        print(obj)
-                        breakpoint()
-                        raise e
         res_dict = {}
 
         res_dict['test_module'] = self.get_name()
@@ -349,7 +313,7 @@ class generic_results():
         else:
             res_dict['summary'] = {'passes': bool(self)}
         return json.dumps(res_dict, indent=2,
-                          ensure_ascii=False, cls=CustomJSONizer)
+                          ensure_ascii=False, cls=PyICeJSONEncoder)
 
 
 class Test_Results(generic_results):


### PR DESCRIPTION
Crash logs now accommodate numpy objects.

Quitting a debugger neither makes a crash log nor sends an email, but rather shuts down the entire sweep.