### PR TITLE
docs: Move IP-XACT walkthrough from README to module docstring; fix Sphinx entries and all module docstrings

### DIFF
--- a/PyICe/LTC_plot.py
+++ b/PyICe/LTC_plot.py
@@ -6,6 +6,28 @@ SVG format. The standards used herein were compliant with a now defunct
 analog semiconductor company called Linear Technology:
 https://en.wikipedia.org/wiki/Linear_Technology
 
+**Main classes**
+
+- :class:`plot` — single axes object; add traces, histograms, scatter plots,
+  notes, legends, and arrows.
+- :class:`scope_plot` — specialised plot subclass for oscilloscope-style data.
+- :class:`Page` — arranges one or more plots in a grid and renders to PDF or SVG.
+- :class:`Multipage_pdf` — combines multiple :class:`Page` objects into one PDF.
+- :class:`PyICe_data_base` — SQLite reader that supplies data to plot methods.
+- :class:`color_gen` — automatic color cycling through the LT palette.
+
+**Utility functions**
+
+- :func:`smooth` / :func:`smooth_y_vector` — sliding-window smoothing.
+- :func:`data_from_file` — load tab- or comma-delimited data from a file.
+- :func:`list_markers` — print all valid matplotlib marker specifiers.
+
+**Color conversion utilities**
+
+- :func:`CMYK_to_fracRGB`, :func:`fracRGB_to_CMYK`
+- :func:`webRGB_to_fracRGB`, :func:`webRGB_to_RGB`
+- :func:`RGB_to_webRGB`, :func:`fracRGB_to_RGB`
+- :func:`RGB_to_fracRGB`, :func:`fracRGB_to_webRGB`
 
 The objects that can be created with this program are:
   1) plot

--- a/PyICe/lab_core.py
+++ b/PyICe/lab_core.py
@@ -2,7 +2,61 @@
 
 ====================================
 
-changes to this file should be minimal!
+.. warning::
+    Changes to this file should be minimal!
+
+Core channel abstraction and instrument management for PyICe.  All
+higher-level modules (:mod:`~PyICe.twi_instrument`,
+:mod:`~PyICe.spi_instrument`, :mod:`~PyICe.lab_gui`, …) build on the
+classes defined here.
+
+**Channel classes**
+
+- :class:`channel` — base readable/writable channel with formatting,
+  limits, and delegation hooks.
+- :class:`integer_channel` — channel constrained to integer values with
+  bit-width and two's-complement support.
+- :class:`register` — integer_channel extended for hardware register
+  semantics (address, access type, reset value).
+- :class:`results_ord_dict` — :class:`~collections.OrderedDict` subclass
+  returned by bulk reads.
+
+**Grouping and instrument classes**
+
+- :class:`delegator` — metaclass mixin that batches channel I/O into
+  efficient instrument transactions.
+- :class:`channel_group` — collection of channels with bulk read/write
+  and SQLite logging helpers.
+- :class:`instrument` — channel_group subclass representing a single
+  physical instrument.
+- :class:`scpi_instrument` — instrument subclass for VISA/SCPI lab
+  equipment; wraps a VISA resource handle.
+
+**Master and logging**
+
+- :class:`channel_master` / :class:`master` — unified read/write
+  dispatcher across all registered instruments; entry point for most
+  test scripts.
+- :class:`logger` — master subclass that records every read into a
+  SQLite database via :class:`logger_backend`.
+- :class:`logger_backend` — low-level SQLite writer; can be used
+  independently for custom logging pipelines.
+
+**Remote / multiprocessing IPC**
+
+- :class:`remote_channel_group_server` — exposes a channel_group over a
+  multiprocessing Manager socket.
+- :class:`remote_channel_group_client` — client-side proxy that mirrors
+  the server's channels locally.
+- :class:`remote_channel` — channel subclass that forwards I/O to the
+  server.
+
+**Exception hierarchy**
+
+:class:`ChannelException` and subclasses (ChannelAccessException,
+ChannelNameException, ChannelAttributeException, ChannelValueException,
+IntegerChannelValueException, ChannelReadException,
+RemoteChannelGroupException, RegisterFormatException).
 
 Examples:
     >>> from PyICe import lab_core

--- a/PyICe/lab_gui.py
+++ b/PyICe/lab_gui.py
@@ -1,5 +1,54 @@
 """Graphical Interface to Channel Objects.
 
+==========================================
+
+PySide2 / PySide6 GUI for live monitoring and interactive control of
+:mod:`~PyICe.lab_core` channels.  PySide2 is preferred for Python ≤ 3.10;
+PySide6 is used automatically on Python ≥ 3.11.  If neither is installed
+the module still imports but all GUI classes are unavailable.
+
+**Shared data model**
+
+- :class:`data_store` — thread-safe dictionary that holds the latest
+  value, units, and metadata for every displayed channel; shared between
+  the background worker and all widgets.
+
+**Display widgets**
+
+- :class:`display_item` — QLabel that auto-refreshes with the current
+  channel value, coloured by limit status.
+- :class:`display_tag` — static QLabel used as a channel-name label.
+- :class:`display_item_group` — composite widget pairing a display_tag
+  with one or more display_items.
+- :class:`tab_view` — scrollable page of display_item_groups.
+- :class:`tab_group` — QTabWidget that organises multiple tab_views.
+
+**Interactive write**
+
+- :class:`write_channel_dialog` — modal dialog for typing a new value
+  into a writable channel; validates against channel limits before writing.
+
+**Logger subsystem**
+
+- :class:`gui_logger` — QObject that drives periodic SQLite-logging
+  triggered by a QTimer.
+- :class:`logger_item` — QCheckBox widget that enables / disables logging
+  for a single channel.
+- :class:`logger_view` — widget that collects logger_items and exposes
+  start / stop controls.
+
+**Background worker**
+
+- :class:`background_worker` — QThread subclass that polls channels at a
+  configurable rate and pushes results into data_store.
+
+**Main window and application**
+
+- :class:`ltc_lab_gui_main_window` — QMainWindow that hosts tab_group,
+  logger_view, and toolbar actions.
+- :class:`ltc_lab_gui_app` — QObject application wrapper; instantiate and
+  call ``exec_()`` to run the event loop.
+
 >>> from PyICe.lab_gui import data_store
 
 """

--- a/PyICe/spi_instrument.py
+++ b/PyICe/spi_instrument.py
@@ -2,6 +2,23 @@
 
 ===============================
 
+Wraps linear shift-register SPI devices as PyICe channel collections.
+Each bitfield in the shift register becomes a readable/writable
+:class:`~PyICe.lab_core.integer_channel` managed by the
+:class:`~PyICe.lab_core.delegator` framework.
+
+Not suitable for context-sensitive (sub-addressed) memory directly; use
+multiple :class:`spiInstrument` instances with distinct ``preamble_clk_cnt``
+and ``preamble_data`` settings for that case.
+
+:class:`spiInstrument` — primary class; inherits from
+    :class:`~PyICe.lab_core.instrument` and
+    :class:`~PyICe.lab_core.delegator`.  Accepts separate write and read
+    :class:`~PyICe.spi_interface.shift_register` objects so that the outgoing
+    and incoming bit layouts can differ.  The class method
+    ``from_ipxact()`` constructs and fully populates an instance from an
+    IEEE 1685-2014 / SPIRIT 1685-2009 IP-XACT component file.
+
 >>> from PyICe.spi_instrument import spiInstrument
 
 """

--- a/PyICe/spi_interface.py
+++ b/PyICe/spi_interface.py
@@ -5,15 +5,30 @@
 Created on Feb 23, 2015
 Heavily modified August 2016 to be more generic.
 
-@author: JKapasi
-@author: DSimmons
+:author: JKapasi
+:author: DSimmons
 
 The SPI interface is composed of two separate classes:
 
-1) shift_register
-    abstracts individual bit-fields into integer representing contents of full-length shift register
-2) spiInterface: Defines the hardware interface including baudrate, mode (CPOL/CPHA), CS operation.
-    Specific hardware implementations should overload this class and implement _shift_data method.
+1) :class:`shift_register` — abstracts individual bit-fields into an integer
+   representing the full-length shift register.  Supports ``pack`` (assemble
+   field dict → integer) and ``unpack`` (integer → field dict).
+2) :class:`spiInterface` — defines the hardware interface including baudrate,
+   mode (CPOL/CPHA), and CS operation.  Concrete subclasses implement
+   ``_shift_data``.
+
+**Hardware backends**
+
+- :class:`spi_bbone` — BeagleBone Black SPI via *Adafruit_BBIO* (optional).
+- :class:`spi_cfgpro` — Linduino / DC590-compatible ConfigPro USB adapter.
+- :class:`spi_dc590` — Linear Technology DC590B USB serial bridge.
+- :class:`spi_buspirate` — Dangerous Prototypes Bus Pirate.
+- :class:`spi_bitbang` — software bit-bang SPI over GPIO.
+- :class:`spi_dummy` — no-op backend for unit testing without hardware.
+
+**Exception**
+
+- :class:`SPIMasterError` — raised when the SPI master reports a fault.
 
 Examples:
     >>> from PyICe.spi_interface import shift_register

--- a/PyICe/twi_instrument.py
+++ b/PyICe/twi_instrument.py
@@ -1,8 +1,35 @@
-"""Channel Wraper for SMBus Compliant Devices.
+"""Channel Wrapper for SMBus/I2C Compliant Devices.
 
 ==========================================
 
-Can automatically populate channels/reisters from XML description
+Wraps SMBus/I2C slave devices as PyICe channel collections, mapping every
+register bitfield to a readable/writable :class:`~PyICe.lab_core.channel`.
+Automatic read-modify-write handles sub-register bitfield access, and
+configurable retry logic tolerates transient bus errors.
+
+Register maps can be loaded programmatically or imported from several
+description formats:
+
+- ``populate_from_xml()`` — legacy PyICe XML register-map files
+- ``populate_from_yoda_json_bridge()`` — Yoda JSON bridge export
+- ``populate_from_ipxact()`` — IEEE 1685-2014 / SPIRIT 1685-2009 IP-XACT
+
+:class:`twi_instrument` — primary instrument class; inherits from
+    :class:`~PyICe.lab_core.instrument` and
+    :class:`~PyICe.lab_core.delegator`.
+
+:class:`twi_register` — :class:`~PyICe.lab_core.register` subclass that
+    carries the SMBus command code and access width for a single register.
+
+:class:`pmbus_instrument` — :class:`twi_instrument` subclass with PMBus
+    extended-command support (0xFF / 0xFE command extensions).
+
+:class:`twi_instrument_dummy` — no-hardware stub useful for unit tests and
+    offline register-map inspection.
+
+.. note::
+    Changes to this file should be coordinated with ``lab_core`` and
+    ``twi_interface`` maintainers.
 
 >>> from PyICe.twi_instrument import twi_instrument
 

--- a/PyICe/twi_interface.py
+++ b/PyICe/twi_interface.py
@@ -2,6 +2,43 @@
 
 ================================
 
+Provides hardware-backend drivers for I2C/SMBus communication.  Uses the
+**Template Method** pattern: :class:`twi_interface` defines the full public
+API and default bit-bang implementations; subclasses override only the
+hardware-specific primitives.
+
+**Architecture**
+
+User code calls protocol-named convenience methods (``write_byte``,
+``read_word``, …) which delegate to ``write_register`` / ``read_register``
+for argument validation, then to ``_do_write_register`` /
+``_do_read_register`` for backend dispatch.  A backend that implements the
+five I2C byte primitives (``start``, ``stop``, ``write_byte_raw``,
+``read_byte_raw``, ``nack``) automatically inherits full protocol support.
+
+**Hardware backends**
+
+- :class:`i2c_dummy` — memory-backed stub (``mem_dict``) for unit tests and
+  offline development; supports PEC simulation.
+- :class:`i2c_buspirate` — Bus Pirate USB adapter.
+- :class:`i2c_pic` — PIC-based USB I2C adapter.
+- :class:`i2c_scpi` — SCPI / VISA instrument acting as an I2C master.
+- :class:`i2c_dc590` — Linear Technology DC590 USB demo board.
+- :class:`i2c_firmata` — Firmata-compatible microcontroller (e.g. Arduino).
+- :class:`i2c_bobbytalk` — proprietary BobbyTalk serial bridge.
+- :class:`i2c_labcomm` — LabComm serial bridge.
+
+**PMBus extensions**
+
+``PMBUS_COMMAND_EXTENSION = 0xFF`` and ``MFR_SPECIFIC_COMMAND_EXT = 0xFE``
+constants, plus extended write/read helpers used by
+:class:`~PyICe.twi_instrument.pmbus_instrument`.
+
+**Exception hierarchy**
+
+Raised on bus errors: ``TwiError``, ``TwiNackError``, ``TwiTimeoutError``,
+``TwiArbitrationLostError``.
+
 Examples:
     >>> from PyICe.twi_interface import i2c_dummy
     >>> bus = i2c_dummy(delay=0, p_change=0)

--- a/PyICe/virtual_instruments.py
+++ b/PyICe/virtual_instruments.py
@@ -1,4 +1,56 @@
-"""Virtual instruments module.
+"""Software-only instruments that compute derived quantities from hardware channels.
+
+All classes extend :class:`lab_core.instrument` and integrate with the PyICe
+channel/measurement framework without requiring physical hardware.
+
+**Math / signal-processing instruments**
+
+- :class:`ramp_to` — incrementally ramp a forcing channel to a target value.
+- :class:`calibrator` — remap write values through a two-point or polynomial transform.
+- :class:`expression_eval` — evaluate arbitrary Python expressions over channel values.
+- :class:`polynomial` — apply a polynomial to a channel reading.
+- :class:`accumulator` — running sum of channel readings.
+- :class:`integrator` — time-integrated accumulator.
+- :class:`differencer` — difference between two channel readings.
+- :class:`differentiator` — numerical derivative of a channel over time.
+- :class:`vector_to_scalar_converter` — reduce a vector channel to a scalar via a supplied function.
+
+**Timing**
+
+- :class:`timer` — elapsed-time channel with start/stop/reset.
+- :class:`delay_loop` — instrument wrapper around :mod:`lab_utils.delay_loop`.
+
+**Control loops**
+
+- :class:`servo` — general PID-style servo controller (e.g. Kelvin forcing).
+- :class:`servo_group` — coordinate multiple servo instances into simultaneous regulation.
+- :class:`simple_servo` — lightweight single-parameter servo.
+- :class:`leakage_nuller` — nulls leakage current by adjusting a compensation channel.
+- :class:`servo_binary_search` — binary-search servo for threshold finding.
+- :class:`threshold_finder` — automatic threshold and hysteresis finder.
+
+**Peak / search**
+
+- :class:`peak_finder` — tracks running peak (min or max) of a channel.
+
+**Digital I/O helpers**
+
+- :class:`dummy` / :class:`dummy_read` / :class:`dummy_write` — no-op channels for
+  replacing missing equipment or logging only.
+- :class:`dummy_quantum_twin` — mirrors live channel state for post-shutdown logging.
+
+**Thermal**
+
+- :class:`Virtual_Oven` — shell temperature-chamber instrument for tests without a real oven.
+
+**Other**
+
+- :class:`instrument_humanoid` — prompt a human operator as part of an automated sequence.
+- :class:`expect` — assert a channel reading is within tolerance of an expected value.
+- :class:`clipboard` — read/write system clipboard as a channel.
+- :class:`aggregator` — combine multiple channels into one composite channel.
+- :class:`smart_battery_emulator` — threaded writers for smart-battery charger control.
+- :class:`digital_analog_io` — digital I/O using analog force/measure channels.
 
 Examples:
     >>> from PyICe import virtual_instruments

--- a/PyICe/visa_wrappers.py
+++ b/PyICe/visa_wrappers.py
@@ -1,7 +1,38 @@
-"""VISA emulation wrappers for physical instrument interfaces.
+"""Transport-agnostic VISA-like interface for instrument communication.
+
+Provides a unified read/write/query API modelled on VISA, implemented over
+multiple physical transport backends.  All optional dependencies are guarded
+by ``try/except`` so the module imports successfully even when a given backend
+library is not installed.
+
+**Base class**
+
+- :class:`visa_wrapper` — abstract base defining ``write``, ``read``,
+  ``query``, ``close``, and timeout management.
+
+**Transport backends**
+
+- :class:`visa_wrapper_serial` — RS-232/RS-485 via *pyserial* (optional).
+- :class:`visa_wrapper_tcp` — raw TCP socket (extends ``visa_wrapper_serial``).
+- :class:`visa_wrapper_telnet` — Telnet via *telnetlib* (optional).
+- :class:`visa_wrapper_vxi11` — VXI-11 LAN instrument via *python-vxi11* (optional).
+- :class:`visa_wrapper_usbtmc` — USB TMC via *python-usbtmc* (optional).
+
+**PyVISA integration**
+
+- :class:`visa_interface` — thin wrapper around *pyvisa* (optional); exposes the
+  same API as the other backends so callers are transport-agnostic.
+
+**Utility functions**
+
+- :func:`strify` — decode a ``bytes`` object to ``str`` using latin-1 encoding.
+- :func:`byteify` — encode a ``str`` to ``bytes`` using latin-1 encoding.
+
+**Exception**
+
+- :class:`visaWrapperException` — raised for transport-level errors.
 
 >>> from PyICe.visa_wrappers import strify
-
 """
 import traceback
 import struct

--- a/README.md
+++ b/README.md
@@ -17,33 +17,6 @@ description. Register maps can be imported from proprietary XML, Yoda JSON, or
 industry-standard IP-XACT (IEEE 1685-2014 / SPIRIT 1685-2009) files via
 `twi_instrument.populate_from_ipxact()` and `spiInstrument.from_ipxact()`.
 
-## IP-XACT Register Map Import
-
-PyICe can import register maps directly from IP-XACT XML files (IEEE 1685-2014 / SPIRIT 1685-2009).
-
-**Command-line conversion (no Python required):**
-```console
-python -m PyICe.ipxact_parser my_device.xml -o my_device_regmap.json
-```
-
-**Python — direct import (skip JSON):**
-```python
-from PyICe.twi_instrument import twi_instrument
-
-inst = twi_instrument(interface)
-inst.populate_from_ipxact("my_device.xml", addr7=0x50)
-```
-
-**Python — convert to JSON first, then import:**
-```python
-from PyICe.ipxact_parser import ipxact_to_pyice_json
-
-ipxact_to_pyice_json("my_device.xml", output_file="my_device_regmap.json")
-```
-
-See `python -m PyICe.ipxact_parser --help` for all CLI options, or
-`help(PyICe.ipxact_parser)` for the full module walkthrough.
-
 For more detailed documentation, please go [here](https://pyice-adi.github.io/PyICe/)
 
 # [PyICe contributors, please go here for install instructions](https://github.com/PyICe-ADI/PyICe/blob/main/CONTRIBUTING.md)

--- a/docs/PyICe.rst
+++ b/docs/PyICe.rst
@@ -24,34 +24,10 @@ PyICe.LTC\_plot module
    :undoc-members:
    :show-inheritance:
 
-PyICe.TypicalCurveEditor\_input module
---------------------------------------
-
-.. automodule:: PyICe.TypicalCurveEditor_input
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-PyICe.generate\_docs module
+PyICe.ipxact\_parser module
 ---------------------------
 
-.. automodule:: PyICe.generate_docs
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-PyICe.interpolator module
--------------------------
-
-.. automodule:: PyICe.interpolator
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-PyICe.ivy\_instruments module
------------------------------
-
-.. automodule:: PyICe.ivy_instruments
+.. automodule:: PyICe.ipxact_parser
    :members:
    :undoc-members:
    :show-inheritance:
@@ -64,6 +40,13 @@ PyICe.lab\_core module
    :undoc-members:
    :show-inheritance:
 
+PyICe.lab\_gui module
+---------------------
+
+.. automodule:: PyICe.lab_gui
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 PyICe.lab\_instruments module
 -----------------------------
@@ -97,14 +80,6 @@ PyICe.logo module
    :undoc-members:
    :show-inheritance:
 
-PyICe.plot\_tools module
-------------------------
-
-.. automodule:: PyICe.plot_tools
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 PyICe.spi\_instrument module
 ----------------------------
 
@@ -129,10 +104,10 @@ PyICe.twi\_instrument module
    :undoc-members:
    :show-inheritance:
 
-PyICe.twoWireInterface module
------------------------------
+PyICe.twi\_interface module
+---------------------------
 
-.. automodule:: PyICe.twoWireInterface
+.. automodule:: PyICe.twi_interface
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
The detailed IP-XACT usage section was awkwardly placed in the middle of the top-level README rather than in the ipxact_parser module where it belongs (and already existed in the module docstring).

## Changes

- **README.md**: Remove redundant 27-line IP-XACT Register Map Import section
- **docs/PyICe.rst**: Remove 6 stale Sphinx autodoc entries (generate_docs, interpolator, ivy_instruments, plot_tools, twoWireInterface, TypicalCurveEditor_input); add missing entries for lab_gui and twi_interface
- **Module docstrings**: Update all module-level docstrings to accurately reflect current contents:
  - twi_instrument (fix spelling, add IP-XACT/JSON/PMBus)
  - spi_instrument (add from_ipxact)
  - lab_core (channels, instruments, logger, remote IPC)
  - lab_gui (PySide2/6 subsystems)
  - twi_interface (Template Method, all backends, PEC/PMBus)
  - virtual_instruments (categorize all 30+ instruments)
  - visa_wrappers (transport backends, utilities)
  - LTC_plot (scope_plot, color utilities, data helpers)
  - spi_interface (backend list, SPIMasterError)