### PR TITLE
Remove duplicate docstring lines across lab_instruments.

### DIFF
--- a/PyICe/lab_instruments/AD5259.py
+++ b/PyICe/lab_instruments/AD5259.py
@@ -101,15 +101,7 @@ class AD5259(instrument):
 
     def add_channel_wiper(self, channel_name):
         """Add a channel wiper.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -135,15 +127,7 @@ class AD5259(instrument):
 
     def add_channel_code(self, channel_name):
         """Add a channel code.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -157,15 +141,7 @@ class AD5259(instrument):
 
     def add_channel_code_readback(self, channel_name):
         """Add a channel code readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/AD5272.py
+++ b/PyICe/lab_instruments/AD5272.py
@@ -151,15 +151,7 @@ class AD5272(instrument):
 
     def add_channel_code(self, channel_name):
         """Add a channel code.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -172,15 +164,7 @@ class AD5272(instrument):
 
     def add_channel_percent(self, channel_name):
         """Add a channel percent.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -193,15 +177,7 @@ class AD5272(instrument):
 
     def add_channel_resistance(self, channel_name):
         """Add a channel resistance.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -215,15 +191,7 @@ class AD5272(instrument):
 
     def add_channel_code_readback(self, channel_name):
         """Add a channel code readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -235,15 +203,7 @@ class AD5272(instrument):
 
     def add_channel_percent_readback(self, channel_name):
         """Add a channel percent readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -260,15 +220,7 @@ class AD5272(instrument):
 
     def add_channel_resistance_readback(self, channel_name):
         """Add a channel resistance readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -286,15 +238,7 @@ class AD5272(instrument):
 
     def add_channel_enable(self, channel_name):
         """Add a channel enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/AD5667R.py
+++ b/PyICe/lab_instruments/AD5667R.py
@@ -186,15 +186,7 @@ class AD5667R(instrument):
 
     def add_channel_DAC_A(self, channel_name):
         """Add a channel DAC A.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -208,15 +200,7 @@ class AD5667R(instrument):
 
     def add_channel_DAC_B(self, channel_name):
         """Add a channel DAC B.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -230,15 +214,7 @@ class AD5667R(instrument):
 
     def add_channel_code_DAC_A(self, channel_name):
         """Add a channel code DAC A.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -253,15 +229,7 @@ class AD5667R(instrument):
 
     def add_channel_code_DAC_B(self, channel_name):
         """Add a channel code DAC B.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -276,15 +244,7 @@ class AD5667R(instrument):
 
     def add_channel_powerstate_DAC_A(self, channel_name):
         """Add a channel powerstate DAC A.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -301,15 +261,7 @@ class AD5667R(instrument):
 
     def add_channel_powerstate_DAC_B(self, channel_name):
         """Add a channel powerstate DAC B.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/AD5693R.py
+++ b/PyICe/lab_instruments/AD5693R.py
@@ -155,15 +155,7 @@ class AD5693R(instrument):
 
     def add_channel(self, channel_name):
         """Add a channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -177,15 +169,7 @@ class AD5693R(instrument):
 
     def add_channel_code(self, channel_name):
         """Add a channel code.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -200,15 +184,7 @@ class AD5693R(instrument):
 
     def add_channel_outputz(self, channel_name):
         """Add a channel outputz.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -220,15 +196,7 @@ class AD5693R(instrument):
 
     def add_channel_gain(self, channel_name):
         """Add a channel gain.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/ADT7410.py
+++ b/PyICe/lab_instruments/ADT7410.py
@@ -118,15 +118,7 @@ class ADT7410(instrument):
 
     def add_channel(self, channel_name):
         """Add a channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/CAT5140.py
+++ b/PyICe/lab_instruments/CAT5140.py
@@ -103,15 +103,7 @@ class CAT5140(instrument):
 
     def add_channel_code(self, channel_name):
         """Add a channel code.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -123,15 +115,7 @@ class CAT5140(instrument):
 
     def add_channel_percent(self, channel_name):
         """Add a channel percent.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -144,15 +128,7 @@ class CAT5140(instrument):
 
     def add_channel_code_readback(self, channel_name):
         """Add a channel code readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -164,15 +140,7 @@ class CAT5140(instrument):
 
     def add_channel_percent_readback(self, channel_name):
         """Add a channel percent readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -207,15 +175,7 @@ class CAT5140(instrument):
 
     def add_channel_select_nonvolatile_register(self, channel_name):
         """Add a channel select nonvolatile register.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -229,15 +189,7 @@ class CAT5140(instrument):
 
     def add_channel_select_volatile_register(self, channel_name):
         """Add a channel select volatile register.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/EL34143A.py
+++ b/PyICe/lab_instruments/EL34143A.py
@@ -68,14 +68,8 @@ class EL34143A(scpi_instrument):
 
     def add_channel_current(self, channel_name, curr_range='AUTO'):
         """Add single CC forcing channel and force zero current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             curr_range: Curr range to use.
@@ -123,15 +117,7 @@ class EL34143A(scpi_instrument):
 
     def add_channel_isense(self, channel_name):
         """Add single current readback channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -147,15 +133,7 @@ class EL34143A(scpi_instrument):
 
     def add_channel_vsense(self, channel_name):
         """Add single voltage readback channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -171,15 +149,7 @@ class EL34143A(scpi_instrument):
 
     def add_channel_psense(self, channel_name):
         """Read back computed power dissipated in load.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -195,15 +165,7 @@ class EL34143A(scpi_instrument):
 
     def add_channel_mode(self, channel_name):
         """Read back operating mode (Off, Constant Current, Constant Voltage, Constant Power, Constant Resistance).
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -260,14 +222,8 @@ class EL34143A(scpi_instrument):
 
     def add_channel_remote_sense(self, channel_name):
         """Enable/disable remote voltage sense through panel connectors.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
 
@@ -283,15 +239,7 @@ class EL34143A(scpi_instrument):
 
     def add_channel_voltage(self, channel_name, volt_range='AUTO'):
         """Add single CV forcing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             volt_range: Volt range to use.
@@ -337,15 +285,7 @@ class EL34143A(scpi_instrument):
 
     def add_channel_power(self, channel_name, pow_range='AUTO'):
         """Add single CW forcing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             pow_range: Pow range to use.
@@ -392,15 +332,7 @@ class EL34143A(scpi_instrument):
 
     def add_channel_resistance(self, channel_name):
         """Add single CR forcing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/ENA.py
+++ b/PyICe/lab_instruments/ENA.py
@@ -172,15 +172,7 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channels(self, channel_name, channel_number=1):
         """Shortcut method to add chx/trace1 channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Base name for the channels.
             channel_number: Instrument channel number.
@@ -201,14 +193,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channel_display_split(self, channel_name, channel_number):
         """Add a channel display split.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -297,15 +283,7 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channel_error(self, channel_name):
         """Error readback channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the error channel.
 
@@ -348,15 +326,7 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
     def add_channel_ydata(self, channel_name,
                           trace_number=1, channel_number=1):
         """Trace data vector.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the y-data channel.
             trace_number: Trace number on the instrument.
@@ -380,15 +350,7 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channel_xdata(self, channel_name, channel_number=1):
         """Frequency sweep data vector.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the x-data channel.
             channel_number: Instrument channel number.
@@ -407,14 +369,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channel_start_freq(self, channel_name, channel_number=1):
         """Sweep start (low) frequency control.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the start frequency channel.
             channel_number: Instrument channel number.
@@ -445,14 +401,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channel_stop_freq(self, channel_name, channel_number=1):
         """Sweep stop (high) frequency control.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the stop frequency channel.
             channel_number: Instrument channel number.
@@ -482,14 +432,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channel_points(self, channel_name, channel_number=1):
         """Number of trace data points.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the points channel.
             channel_number: Instrument channel number.
@@ -515,14 +459,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channel_sweep_type(self, channel_name, channel_number=1):
         """Sweep variable control.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the sweep type channel.
             channel_number: Instrument channel number.
@@ -550,14 +488,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channel_IFBW(self, channel_name, channel_number=1):
         """IF/resolution bandwidth. TODO: Disrespected when IFBW set to AUTO.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the IFBW channel.
             channel_number: Instrument channel number.
@@ -595,14 +527,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channel_sweep_time(self, channel_name, channel_number=1):
         """Sweep time control.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SWEep:TIME:DATA`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the sweep time channel.
             channel_number: Instrument channel number.
@@ -635,7 +561,6 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
         """Display control channel.
 
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the display channel.
         """
@@ -644,14 +569,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channels_gp_control(self, channel_name):  # todo channl number???
         """General purpose port control channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Base name for the GP control channels.
 
@@ -719,14 +638,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
 
     def add_channels_bias_control(self, channel_name):  # TODO channel number!
         """Bias sweep currently unsupported TODO.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Base name for the bias control channels.
 
@@ -781,14 +694,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
     # TODO channel number!
     def add_channels_source_power(self, channel_name, port='GP'):
         """Source power control in dBm.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the source power channel.
             port: Port selection, either 'GP' or a port number.
@@ -876,14 +783,8 @@ class keysight_e5061b_base(scpi_NA, metaclass=abc.ABCMeta):
         # TODO channel number!
         # todo all-channel controls?
         """Trigger control channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:SEQuence:SOURce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Base name for the trigger channels.
 
@@ -1021,15 +922,7 @@ class keysight_e5061b(keysight_e5061b_base):
     # super(keysight_e5061b, self).__init__(interface_visa)
     def add_channels(self, channel_name, channel_number=1):
         """Add a channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -1050,7 +943,6 @@ class keysight_e5061b(keysight_e5061b_base):
         """Limit channel.
 
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the limit channel.
         """
@@ -1059,14 +951,8 @@ class keysight_e5061b(keysight_e5061b_base):
 
     def add_channel_TR_mag(self, channel_name, trace_number, channel_number=1):
         """T/R log magnitude measurement channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SELect`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the TR magnitude channel.
             trace_number: Trace number on the instrument.
@@ -1112,14 +998,8 @@ class keysight_e5061b(keysight_e5061b_base):
 
     def add_channel_T_mag(self, channel_name, trace_number, channel_number=1):
         """T log magnitude measurement channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SELect`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the T magnitude channel.
             trace_number: Trace number on the instrument.
@@ -1166,14 +1046,8 @@ class keysight_e5061b(keysight_e5061b_base):
 
     def add_channel_R_mag(self, channel_name, trace_number, channel_number=1):
         """R log magnitude measurement channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SELect`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the R magnitude channel.
             trace_number: Trace number on the instrument.
@@ -1221,14 +1095,8 @@ class keysight_e5061b(keysight_e5061b_base):
     def add_channel_TR_phase(
             self, channel_name, trace_number, channel_number=1):
         """T/R expanded phase measurement channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SELect`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the TR phase channel.
             trace_number: Trace number on the instrument.
@@ -1379,14 +1247,8 @@ class keysight_e5061b(keysight_e5061b_base):
     def add_channel_sparam(
             self, channel_name, trace_number, x, y, channel_number=1):
         """S-parameter log magnitude measurement channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SELect`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the S-parameter channel.
             trace_number: Trace number on the instrument.
@@ -1439,7 +1301,6 @@ class keysight_e5061b(keysight_e5061b_base):
         """Calibration control channels.
 
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Base name for the calibration channels.
         """
@@ -1556,15 +1417,7 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channels(self, channel_name, channel_number=1):
         """Add a channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -1584,14 +1437,8 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channel_zmethod(self, channel_name, channel_number=1):
         """Impedance measurement method control channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the Z method channel.
             channel_number: Instrument channel number.
@@ -1648,14 +1495,8 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
     def add_channel_zparameter(
             self, channel_name, trace_number=1, channel_number=1):
         """Impedance parameter selection channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SELect`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the Z parameter channel.
             trace_number: Trace number on the instrument.
@@ -1703,14 +1544,8 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channel_zcorrection_open(self, channel_name, channel_number=1):
         """Open load complex correction vector.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the open correction channel.
             channel_number: Instrument channel number.
@@ -1731,14 +1566,8 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channel_zcorrection_short(self, channel_name, channel_number=1):
         """Shorted load complex correction vector.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the short correction channel.
             channel_number: Instrument channel number.
@@ -1759,14 +1588,8 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channel_zcorrection_load(self, channel_name, channel_number=1):
         """50 Ohm load complex correction vector.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the load correction channel.
             channel_number: Instrument channel number.
@@ -1787,15 +1610,7 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channels_impedance_setup(self, channel_name, channel_number=1):
         """Shortcut to add impedance measurement control channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Base name for the impedance setup channels.
             channel_number: Instrument channel number.
@@ -1821,15 +1636,7 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channels_zcorrection(self, channel_name, channel_number=1):
         """Z correction channels for open, short, and load.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Base name for the Z correction channels.
             channel_number: Instrument channel number.
@@ -1855,14 +1662,8 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channel_zcorrection_collect(self, channel_name, channel_number=1):
         """Z correction collection channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the Z correction collect channel.
             channel_number: Instrument channel number.
@@ -1941,11 +1742,7 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channels_impedance_equiv_A(self, channel_name, channel_number=1):
         """Parallel RLC. Model A - Generally suited to analyze inductors with high core loss.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Base name for the equivalent circuit channels.
             channel_number: Instrument channel number.
@@ -1958,11 +1755,7 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channels_impedance_equiv_B(self, channel_name, channel_number=1):
         """C parallel R+L. Model B - Generally suited to analyze general inductors and resistors.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Base name for the equivalent circuit channels.
             channel_number: Instrument channel number.
@@ -1975,11 +1768,7 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channels_impedance_equiv_C(self, channel_name, channel_number=1):
         """L series C//R. Model C - Generally suited to analyze resistors with high resistance.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Base name for the equivalent circuit channels.
             channel_number: Instrument channel number.
@@ -1992,11 +1781,7 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channels_impedance_equiv_D(self, channel_name, channel_number=1):
         """Series RLC. Model D - Generally suited to analyze capacitors.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Base name for the equivalent circuit channels.
             channel_number: Instrument channel number.
@@ -2009,15 +1794,7 @@ class keysight_e5061b_impedance(keysight_e5061b_base):
 
     def add_channels_impedance_equiv_E(self, channel_name, channel_number=1):
         """C0 parallel Series RLC. Model E - Generally suited to analyze resonators and oscillators.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Base name for the equivalent circuit channels.
             channel_number: Instrument channel number.

--- a/PyICe/lab_instruments/Franken_oven.py
+++ b/PyICe/lab_instruments/Franken_oven.py
@@ -35,15 +35,7 @@ class Franken_oven(autonicstk, temperature_chamber):
 
     def add_channels(self, channel_name):
         """Add a channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/PCF8574.py
+++ b/PyICe/lab_instruments/PCF8574.py
@@ -33,15 +33,7 @@ class PCF8574(instrument):
 
     def add_channel_writepin(self, channel_name, pin):
         """Adds a single output pin to control. State is held locally since the pins are hi Z up they can't be relied upon to hold state.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             pin: Pin number.
@@ -59,15 +51,7 @@ class PCF8574(instrument):
 
     def add_channel_readpin(self, channel_name, pin):
         """Adds a single input pin to read back.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             pin: Pin number.

--- a/PyICe/lab_instruments/PSA.py
+++ b/PyICe/lab_instruments/PSA.py
@@ -186,15 +186,7 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_ydata(self, channel_name, trace_number=1):
         """Trace data vector.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             trace_number: Trace number to use.
@@ -216,15 +208,7 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_xdata(self, channel_name):
         """Frequency sweep data vector.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -242,14 +226,8 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_sweep_control(self, channel_name):
         """Add sweep control channels (start, stop, center, span frequency).
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -528,15 +506,9 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_RBW_auto(self, channel_name):
         """Tracks the state of the AUTO setting for the resolution bandwidth.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SENSe:BANDwidth:RESolution:AUTO`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -616,14 +588,8 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_VBW_auto(self, channel_name):
         """Tracks the state of the AUTO setting for the video bandwidth and the RBW/VBW ratio channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -901,14 +867,8 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_attenuator_auto(self, channel_name):
         """Tracks the state of the AUTO setting for the front end attenuators.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -1273,14 +1233,8 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_trigger(self, channel_name):
         """Add trigger control channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -1456,14 +1410,8 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_sweep_time(self, channel_name):
         """Calculated time for single sweep, dependent on start/stop/points/rbw/etc.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -1487,14 +1435,8 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_sweep_time_auto(self, channel_name):
         """Tracks the state of the AUTO setting for the sweep time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -1515,14 +1457,8 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_message(self, channel_name):
         """Write message to lower left corner of screen display.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -1917,14 +1853,8 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_fullscreen(self, channel_name):
         """Turns off the screen buttons temporarily for more usful viewing. They will come back on if other user inputs require them.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -1945,14 +1875,8 @@ class keysight_e4440a(scpi_SA):
 
     def add_channel_syst_error(self, channel_name):
         """Returns the response to :SYSTem:ERROr? to see if there are any commands making the instrument angry. Perform repeated reads to get them all and clear the buffer.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -1978,15 +1902,7 @@ class keysight_e4440a(scpi_SA):
 
     def add_channels(self, channel_name):
         """Add all instrument channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/TDS640A.py
+++ b/PyICe/lab_instruments/TDS640A.py
@@ -33,15 +33,7 @@ class TDS640A(scpi_instrument, delegator):
 
     def add_channel_time(self, channel_name):
         """Add a channel time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -56,15 +48,7 @@ class TDS640A(scpi_instrument, delegator):
 
     def add_channel(self, channel_name, scope_channel_number):
         """Add named channel to instrument. num is 1-4.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             scope_channel_number: Oscilloscope channel number (1-based).

--- a/PyICe/lab_instruments/TMP117.py
+++ b/PyICe/lab_instruments/TMP117.py
@@ -109,15 +109,7 @@ class TMP117(instrument):
 
     def add_channel(self, channel_name):
         """Add a channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/TestEquity_115.py
+++ b/PyICe/lab_instruments/TestEquity_115.py
@@ -35,15 +35,7 @@ class TestEquity_115(temperature_chamber):
 
     def add_channels(self, channel_name):
         """Add a channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -55,15 +47,7 @@ class TestEquity_115(temperature_chamber):
 
     def add_channel_enable_output(self, channel_name):
         """Enable/Disable heat and cool outputs.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/a3497x_instruments.py
+++ b/PyICe/lab_instruments/a3497x_instruments.py
@@ -386,15 +386,7 @@ class agilent_3497xa_20ch_40ch(a3497xa_instrument):
     def add_channel_dc_voltage(self, channel_name, channel_num, NPLC=1, range="AUTO",
                                high_z=True, delay=None, disable_autozero=True, Rsource=None, fmt=':3.6g'):
         """Shortcut method to add voltage channel and configure in one step.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new voltage channel.
             channel_num: Physical channel number on the mux card.
@@ -444,15 +436,7 @@ class agilent_3497xa_20ch_40ch(a3497xa_instrument):
     def add_channel_thermocouple(
             self, channel_name, channel_num, tcouple_type, NPLC=1, disable_autozero=True):
         """Shortcut method to add thermistor measurement channel and configure in one step.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new thermocouple channel.
             channel_num: Physical channel number on the mux card.
@@ -479,15 +463,7 @@ class agilent_3497xa_20ch_40ch(a3497xa_instrument):
     def add_channel_rtd(self, channel_name, channel_num, rtd_type=85,
                         ptype=4, nom_res=100, NPLC=1, disable_autozero=True):
         """Shortcut method to add rtd measurement channel and configure in one step.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new RTD channel.
             channel_num: Physical channel number on the mux card.
@@ -671,14 +647,8 @@ class agilent_3497xa_20ch_40ch(a3497xa_instrument):
 
     def add_channel_nplc(self, channel_name, base_channel):
         """Adds a secondary channel that can modify the nplc setting of an existing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new NPLC control channel.
             base_channel: The measurement channel whose NPLC to control.
@@ -701,14 +671,8 @@ class agilent_3497xa_20ch_40ch(a3497xa_instrument):
 
     def add_channel_delay(self, channel_name, base_channel):
         """Adds a secondary channel that can modify the delay of an existing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new delay control channel.
             base_channel: The measurement channel whose delay to control.
@@ -788,14 +752,8 @@ class agilent_3497xa_20ch_40ch(a3497xa_instrument):
 
     def add_channel_range_readback(self, channel_name, base_channel):
         """Add a channel range readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``SENSe:VOLTage:DC:RANGe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             base_channel: Base channel object to extend.
             channel_name: Name for the new channel.
@@ -809,14 +767,8 @@ class agilent_3497xa_20ch_40ch(a3497xa_instrument):
 
     def add_channel_gain(self, channel_name, base_channel):
         """Adds a secondary channel that can modify the gain (span multiplier) of an existing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new gain control channel.
             base_channel: The measurement channel whose gain to control.
@@ -844,14 +796,8 @@ class agilent_3497xa_20ch_40ch(a3497xa_instrument):
 
     def add_channel_offset(self, channel_name, base_channel):
         """Adds a secondary channel that can modify the offset of an existing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new offset control channel.
             base_channel: The measurement channel whose offset to control.
@@ -879,14 +825,8 @@ class agilent_3497xa_20ch_40ch(a3497xa_instrument):
 
     def add_channel_unit(self, channel_name, base_channel):
         """Adds a secondary channel that can modify the displayed unit (V/A/etc) of an existing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new unit control channel.
             base_channel: The measurement channel whose display unit to control.
@@ -945,15 +885,7 @@ class agilent_3497xa_20ch(agilent_3497xa_20ch_40ch):
     def add_channel_dc_current(self, channel_name, channel_num,
                                NPLC=1, range='AUTO', delay=None, disable_autozero=True):
         """DC current measurement only allowed on 34901A channels 21 and 22.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new current channel.
             channel_num: Physical channel number (must be 21 or 22).
@@ -1002,14 +934,8 @@ class agilent_3497xa_20ch(agilent_3497xa_20ch_40ch):
 
     def add_channel_ammeter_range(self, channel_name, base_channel):
         """Modify ammeter current range shunt.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new range control channel.
             base_channel: The current measurement channel whose range to control.
@@ -1064,14 +990,8 @@ class agilent_3497xa_20ch(agilent_3497xa_20ch_40ch):
     def add_channel_res(self, channel_name, channel_num, NPLC=1, res_range='AUTO',
                         offset_compensated=True, delay=None, disable_autozero=True, add_extended_channels=True):
         """Two Wire DC resistance measurement.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new resistance channel.
             channel_num: Physical channel number on the mux card.
@@ -1250,14 +1170,8 @@ class agilent_3497xa_20ch(agilent_3497xa_20ch_40ch):
     def add_channel_fres(self, channel_name, channel_num, NPLC=1, range='AUTO',
                          offset_compensated=True, delay=None, disable_autozero=True, add_extended_channels=True):
         """Four Wire DC resistance measurement.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new four-wire resistance channel.
             channel_num: Physical channel number on the mux card.
@@ -1558,15 +1472,7 @@ class agilent_3497xa_dacs(a3497xa_instrument):
 
     def add_channel(self, channel_name, channel_num):
         """Add named DAC channel to instrument.  num is 1-2, mapping to physical channel 4-5.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new DAC channel.
             channel_num: DAC number (1 or 2).
@@ -1594,7 +1500,6 @@ class agilent_3497xa_dacs(a3497xa_instrument):
         """Set named DAC to voltage.  Range is +/-12V with 16bit (366uV) resolution.
         Formats and sends the command to the instrument.
         Sends the ``SOURCE:VOLT`` SCPI command to the instrument.
-        Formats and sends the command to the instrument.
 
         Sends the corresponding SCPI command string to the instrument over the bus.
 
@@ -1643,15 +1548,7 @@ class agilent_3497xa_actuator(a3497xa_instrument):
 
     def add_channel(self, channel_name, channel_num):
         """Channel_num is 1-20.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new actuator channel.
             channel_num: Physical relay channel number (1-20).

--- a/PyICe/lab_instruments/agilent_3034a.py
+++ b/PyICe/lab_instruments/agilent_3034a.py
@@ -290,15 +290,7 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_timebase(self, name):
         """Add a channel timebase.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             name: Name identifier.
 
@@ -539,14 +531,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_probe_gain(self, name, number):
         """Add a channel probe gain.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PROBe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -568,14 +554,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_BWLimit(self, name, number):
         """Add a channel BWLimit.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:BWLimit`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -597,14 +577,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_HFReject(self, name):
         """Add a channel trigger HFReject.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:HFReject`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -622,14 +596,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_invert(self, name, number):
         """Add a channel invert.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:INVert`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -651,14 +619,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_Yrange(self, name, number):
         """Add a channel Yrange.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:CHANnel`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:CHANnel`` SCPI command to the instrument.
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -677,14 +639,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_Yoffset(self, name, number):
         """Add a channel Yoffset.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:CHANnel`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:CHANnel`` SCPI command to the instrument.
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -703,14 +659,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_Yrange_readback(self, name, number):
         """Add a channel Yrange readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:RANGe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -728,14 +678,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_Yoffset_readback(self, name, number):
         """Add a channel Yoffset readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:CHANnel`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -755,14 +699,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_impedance(self, name, number):
         """Add a channel impedance.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:IMPedance`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -791,14 +729,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_units(self, name, number):
         """Add a channel units.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:UNITs`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -827,14 +759,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_coupling(self, name, number):
         """Add a channel coupling.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:COUPling`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -861,14 +787,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_Xrange(self, name):
         """Add a channel Xrange.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TIMebase:RANGe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -884,14 +804,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_Xposition(self, name):
         """Add a channel Xposition.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TIMebase:POSition`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -907,14 +821,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_Xreference(self, name):
         """Add a channel Xreference.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TIMebase:REFerence`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -946,14 +854,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_Xrange_readback(self, name):
         """Add a channel Xrange readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TIMebase:RANGe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -970,14 +872,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_Xposition_readback(self, name):
         """Add a channel Xposition readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TIMebase:POSition`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -996,14 +892,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_Xreference_readback(self, name):
         """Add a channel Xreference readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TIMebase:REFerence`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1019,15 +909,7 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_runmode(self, name):
         """Add a channel runmode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             name: Name identifier.
 
@@ -1044,14 +926,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_triggerlevel(self, name):
         """Add a channel triggerlevel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:LEVel`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1069,14 +945,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_triggermode(self, name):
         """Add a channel triggermode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:SWEep`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1099,14 +969,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_triggerslope(self, name):
         """Add a channel triggerslope.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:SLOPe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1132,14 +996,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_triggersource(self, name):
         """Add a channel triggersource.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:SOURce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1175,14 +1033,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_acquire_type(self, name):
         """Add a channel acquire type.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:ACQuire:TYPE`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1211,14 +1063,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_acquire_count(self, name):
         """Add a channel acquire count.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:ACQuire:COUNt`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1242,15 +1088,7 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_pointcount(self, name):
         """Add a channel pointcount.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             name: Name identifier.
 
@@ -1264,15 +1102,7 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_pointcount_readback(self, name):
         """Add a channel pointcount readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             name: Name identifier.
 
@@ -1287,14 +1117,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_triggertype(self, name):
         """Add a channel triggertype.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the `` Agilent`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1329,14 +1153,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_pattern(self, name):
         """Add a channel trigger pattern.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:PATTern`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1354,15 +1172,9 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_pattern_qualifier(self, name):
         """Add a channel trigger pattern qualifier.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:PATTern:QUALifier`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1392,14 +1204,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_pattern_format(self, name):
         """Add a channel trigger pattern format.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:PATTern:FORMat`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1421,15 +1227,9 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_pattern_greaterthan(self, name):
         """Add a channel trigger pattern greaterthan.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:PATTern:GREaterthan`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1449,15 +1249,9 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_pattern_lessthan(self, name):
         """Add a channel trigger pattern lessthan.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:PATTern:LESSthan`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1477,14 +1271,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_pattern_range(self, name):
         """Add a channel trigger pattern range.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:PATTern:RANGe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1509,15 +1297,9 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_glitch_greaterthan(self, name):
         """Add a channel trigger glitch greaterthan.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:GLITch:GREaterthan`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1537,14 +1319,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_glitch_lessthan(self, name):
         """Add a channel trigger glitch lessthan.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:GLITch:LESSthan`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1564,14 +1340,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_glitch_level(self, name):
         """Add a channel trigger glitch level.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:GLITch:LEVel`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1590,14 +1360,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_glitch_source(self, name):
         """Add a channel trigger glitch source.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:GLITch:SOURce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1616,14 +1380,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_glitch_polarity(self, name):
         """Add a channel trigger glitch polarity.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:GLITch:POLarity`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1648,15 +1406,9 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_glitch_qualifier(self, name):
         """Add a channel trigger glitch qualifier.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:GLITch:QUALifier`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1682,14 +1434,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_glitch_range(self, name):
         """Add a channel trigger glitch range.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:GLITch:RANGe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1714,14 +1460,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_runt_polarity(self, name):
         """Add a channel trigger runt polarity.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:RUNT:POLarity`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1746,14 +1486,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_runt_qualifier(self, name):
         """Add a channel trigger runt qualifier.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:RUNT:QUALifier`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1778,14 +1512,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_runt_source(self, name):
         """Add a channel trigger runt source.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:RUNT:SOURce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1804,14 +1532,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_runt_time(self, name):
         """Add a channel trigger runt time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:RUNT:TIME`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1829,14 +1551,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_runt_level_high(self, name):
         """Add a channel trigger runt level high.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:LEVel:HIGH`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1855,14 +1571,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_trigger_runt_level_low(self, name):
         """Add a channel trigger runt level low.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRIGger:RUNT:SOURce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -1880,14 +1590,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_frequency(self, name, number):
         """Add a channel meas frequency.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:FREQuency`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -1915,14 +1619,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_period(self, name, number):
         """Add a channel meas period.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:PERiod`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -1956,14 +1654,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_stats_current(self, name, number):
         """Add a channel meas stats current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:RESults`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -1981,14 +1673,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_stats_minimum(self, name, number):
         """Add a channel meas stats minimum.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:STATistics`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2006,14 +1692,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_stats_maximum(self, name, number):
         """Add a channel meas stats maximum.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:RESults`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2031,14 +1711,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_stats_mean(self, name, number):
         """Add a channel meas stats mean.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:STATistics`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2056,14 +1730,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_stats_stdev(self, name, number):
         """Add a channel meas stats stdev.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:RESults`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2081,14 +1749,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_stats_count(self, name, number):
         """Add a channel meas stats count.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:STATistics`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2106,15 +1768,9 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_stats_reset(self, name, number):
         """Add a channel meas stats reset.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:STATistics:RESet`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2131,14 +1787,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_dutycycle(self, name, number):
         """Add a channel meas dutycycle.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:SOURce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2163,14 +1813,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_risetime(self, name, number):
         """Add a channel meas risetime.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:SOURce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2195,14 +1839,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_falltime(self, name, number):
         """Add a channel meas falltime.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:SOURce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2241,15 +1879,7 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_display(self, name, number):
         """Add a channel display.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2266,14 +1896,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_delay(self, name, first_channel, second_channel):
         """Add a channel meas delay.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:DELay`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             first_channel: First channel to use.
             name: Name identifier.
@@ -2303,14 +1927,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_delay_spec1(self, name):
         """Add a channel meas delay spec1.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:DEFine`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -2329,14 +1947,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_delay_spec2(self, name):
         """Add a channel meas delay spec2.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:DEFine`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
 
@@ -2355,14 +1967,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_define_abs_thresh(self, name, number):
         """Add a channel meas define abs thresh.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:DEFine`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2383,14 +1989,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_pwidth(self, name, number):
         """Add a channel meas pwidth.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:PWIDth`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2415,14 +2015,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_nwidth(self, name, number):
         """Add a channel meas nwidth.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:SOURce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2447,14 +2041,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_vmax(self, name, number):
         """Add a channel meas vmax.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:SOURce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2479,14 +2067,8 @@ class agilent_3034a(oscilloscope):
 
     def add_channel_meas_vaverage(self, name, number):
         """Add a channel meas vaverage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:MEASure:VAVerage`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             name: Name identifier.
             number: Channel or port number.
@@ -2730,15 +2312,7 @@ class agilent_3034a(oscilloscope):
     @deprecated(version='47', reason="You are using old scope driver methods. Consider updating to new scope binding. See https://confluence.analog.com/display/stowe/Preferred+Practices")
     def add_channel_time(self, name):
         """Add a channel time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             name: Name identifier.
 

--- a/PyICe/lab_instruments/agilent_33220a.py
+++ b/PyICe/lab_instruments/agilent_33220a.py
@@ -105,15 +105,7 @@ class agilent_33220a(scpi_instrument):
 
     def add_channel(self, channel_name, add_extended_channels=True):
         """Add a channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             add_extended_channels: If True, add sense and mode channels.
             channel_name: Name for the new channel.
@@ -137,15 +129,7 @@ class agilent_33220a(scpi_instrument):
 
     def add_channel_low_voltage(self, channel_name):
         """Add a channel low voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -160,15 +144,7 @@ class agilent_33220a(scpi_instrument):
 
     def add_channel_high_voltage(self, channel_name):
         """Add a channel high voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -183,15 +159,7 @@ class agilent_33220a(scpi_instrument):
 
     def add_channel_pulse_width(self, channel_name):
         """Add a channel pulse width.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -208,15 +176,7 @@ class agilent_33220a(scpi_instrument):
 
     def add_channel_pulse_period(self, channel_name):
         """Add a channel pulse period.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -233,15 +193,7 @@ class agilent_33220a(scpi_instrument):
 
     def add_channel_slew_rate(self, channel_name):
         """Add a channel slew rate.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -258,15 +210,7 @@ class agilent_33220a(scpi_instrument):
 
     def add_channel_trigger(self, channel_name):
         """Add a channel trigger.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -281,15 +225,7 @@ class agilent_33220a(scpi_instrument):
 
     def add_channel_cycle_count(self, channel_name):
         """Add a channel cycle count.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/agilent_34401a.py
+++ b/PyICe/lab_instruments/agilent_34401a.py
@@ -130,15 +130,7 @@ class agilent_34401a(scpi_instrument):
 
     def add_channel(self, channel_name):
         """Add named channel to instrument without configuring measurement type.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/agilent_35670a.py
+++ b/PyICe/lab_instruments/agilent_35670a.py
@@ -29,14 +29,8 @@ class agilent_35670a(scpi_instrument):
     def add_channel_noise(self, channel_name, channel_num=1,
                           freqs=None, res=None, count=None):
         """Add a channel noise.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``INPut1:COUPling`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_num: Physical channel number.
@@ -75,15 +69,7 @@ class agilent_35670a(scpi_instrument):
 
     def add_channel(self, channel_name, channel_num):
         """Add named channel to instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_num: Physical channel number.

--- a/PyICe/lab_instruments/agilent_8110a.py
+++ b/PyICe/lab_instruments/agilent_8110a.py
@@ -41,14 +41,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_trigger_source(self, channel_name):
         """Sets the trigger source of the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:ARM:SOUR`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -82,14 +76,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_trigger_sense(self, channel_name):
         """Sets the trigger sense of the instrument to EDGE or LEVEL.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:ARM:SENS`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -109,14 +97,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_trigger_impedance(self, channel_name):
         """Sets the impedance of the EXT INPUT connector.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:ARM:IMP`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -138,14 +120,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_arm_level(self, channel_name):
         """Sets the trigger level of the front panel EXT INPUT trigger input.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:ARM:LEV`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -162,14 +138,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_trigger_slope(self, channel_name):
         """Sets the trigger slope of the EXT INPUT connector.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``'.`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -220,14 +190,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_ouput_state(self, channel_name, number):
         """Sets the output state of each channel to on or off.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:OUTP`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:OUTP`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             number: Channel or port number.
@@ -252,14 +216,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_ouput_polarity(self, channel_name, number):
         """Sets the output polarity of each channel to NORMAL or INVERTED.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:OUTP`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:OUTP`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             number: Channel or port number.
@@ -380,14 +338,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_high_current_level(self, channel_name, number):
         """Sets the high level of the current waveform while being aware of ratio of the downstream impedance and its own source imepdance.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SOUR:CURR`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             number: Channel or port number.
@@ -407,14 +359,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_low_current_level(self, channel_name, number):
         """Sets the Low level of the current waveform while being aware of ratio of the downstream impedance and its own source imepdance.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SOUR:CURR`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             number: Channel or port number.
@@ -434,14 +380,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_transition_leading(self, channel_name, number):
         """Sets the leading edge speed of the waveform.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SOUR:PULS:TRAN`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             number: Channel or port number.
@@ -460,14 +400,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_transition_trailing(self, channel_name, number):
         """Sets the trailing edge speed of the waveform.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:TRA`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             number: Channel or port number.
@@ -551,15 +485,7 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_trigger(self, channel_name):
         """Triggers the instrument (with SCPI *TRG) assuming it's in manual mode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -653,14 +579,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_pattern_state(self, channel_name):
         """Enables the outputs to follow the pattern generator vs just free running pulses.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``DIG:STIM:PATT:STATE`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -682,14 +602,8 @@ class Agilent_8110a(scpi_instrument):
 
     def add_channel_pattern_format(self, channel_name, number):
         """Sets the per-channel output patterns to be RZ or NRZ (Return to Zero or Non Return to Zero).
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:FORM`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             number: Channel or port number.

--- a/PyICe/lab_instruments/agilent_e36xxa.py
+++ b/PyICe/lab_instruments/agilent_e36xxa.py
@@ -12,15 +12,7 @@ class agilent_e36xxa(scpi_instrument):
 
     def add_channel_voltage(self, channel_name, num):
         """Add a channel voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -38,15 +30,7 @@ class agilent_e36xxa(scpi_instrument):
 
     def add_channel_current(self, channel_name, num):
         """Add a channel current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -64,15 +48,7 @@ class agilent_e36xxa(scpi_instrument):
 
     def add_channel_vsense(self, channel_name, num):
         """Add a channel vsense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -86,15 +62,7 @@ class agilent_e36xxa(scpi_instrument):
 
     def add_channel_isense(self, channel_name, num):
         """Add a channel isense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.

--- a/PyICe/lab_instruments/agilent_e4433b.py
+++ b/PyICe/lab_instruments/agilent_e4433b.py
@@ -25,15 +25,7 @@ class agilent_e4433b(instrument):
 
     def add_channel(self, channel_name, add_extended_channels=True):
         """Add a channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             add_extended_channels: If True, add sense and mode channels.
             channel_name: Name for the new channel.
@@ -68,15 +60,7 @@ class agilent_e4433b(instrument):
 
     def add_channel_freq(self, channel_name):
         """Add a channel freq.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -88,15 +72,7 @@ class agilent_e4433b(instrument):
 
     def add_channel_power(self, channel_name):
         """Add a channel power.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/agilent_e53181a.py
+++ b/PyICe/lab_instruments/agilent_e53181a.py
@@ -81,15 +81,7 @@ class agilent_e53181a(scpi_instrument):
 
     def add_channel(self, channel_name):
         """Add named channels to instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -101,15 +93,7 @@ class agilent_e53181a(scpi_instrument):
 
     def add_channel_freq(self, channel_name):
         """Add named frequency channel to instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -121,15 +105,7 @@ class agilent_e53181a(scpi_instrument):
 
     def add_channel_dutycycle(self, channel_name):
         """Add named dutycycle channel to instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/agilent_n3301.py
+++ b/PyICe/lab_instruments/agilent_n3301.py
@@ -41,15 +41,7 @@ class agilent_n3301(scpi_instrument):
 
     def add_channel(self, channel_name, channel_num, add_sense_channel=True):
         """Add current force writable channel. Optionally add current readback _isense channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             add_sense_channel: Add sense channel to use.
             channel_name: Name for the new channel.
@@ -61,15 +53,7 @@ class agilent_n3301(scpi_instrument):
 
     def add_channel_current(self, channel_name, channel_num):
         """Add a channel current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_num: Physical channel number.
@@ -83,15 +67,7 @@ class agilent_n3301(scpi_instrument):
 
     def add_channel_isense(self, channel_name, channel_num):
         """Add a channel isense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_num: Physical channel number.

--- a/PyICe/lab_instruments/autonicstk.py
+++ b/PyICe/lab_instruments/autonicstk.py
@@ -84,15 +84,7 @@ class autonicstk(instrument):
 
     def add_channel_measured(self, channel_name):
         """Measured Temperature Readback (PV).
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -112,15 +104,7 @@ class autonicstk(instrument):
 
     def add_channel_units(self, channel_name):
         """Select Celsius or Farenheit. CAUTION: Units also change PID gains.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -142,15 +126,7 @@ class autonicstk(instrument):
 
     def add_channel_setpoint(self, channel_name):
         """Target Temperature Setpoint (SV).
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -182,15 +158,7 @@ class autonicstk(instrument):
 
     def add_channel_heat_mv(self, channel_name):
         """Heater percent power manipulated variable (MV). Can be written directly in manual mode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -207,15 +175,7 @@ class autonicstk(instrument):
 
     def add_channel_cool_mv(self, channel_name):
         """Cooler percent power manipulated variable (MV). Can be written directly in manual mode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -232,15 +192,7 @@ class autonicstk(instrument):
 
     def add_channel_mode(self, channel_name):
         """Automatic/Manual mode selector. Automatic uses temperature setpoint (SV). Manual uses heat and cool MV setpoints.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -262,15 +214,7 @@ class autonicstk(instrument):
 
     def add_channel_presets(self, channel_name):
         """Select one of 4 pre-selected temperatures.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -294,15 +238,7 @@ class autonicstk(instrument):
 
     def add_channel_alarm1(self, channel_name):
         """Alarm 1 output status.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -322,15 +258,7 @@ class autonicstk(instrument):
 
     def add_channel_alarm2(self, channel_name):
         """Alarm 2 output status.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -350,15 +278,7 @@ class autonicstk(instrument):
 
     def add_channel_enable_output(self, channel_name):
         """Enable/Disable heat and cool outputs.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -383,15 +303,7 @@ class autonicstk(instrument):
 
     def add_channel_heat_cool_mode(self, channel_name):
         """Enable heat only, cool only or heat-cool mode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -414,15 +326,7 @@ class autonicstk(instrument):
 
     def add_channel_autotune(self, channel_name):
         """Start autotune sequence.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -444,15 +348,7 @@ class autonicstk(instrument):
 
     def add_channels_tuning(self, channel_name):
         """PID control gain settings. See: https://en.wikipedia.org/wiki/PID_controller#Alternative_nomenclature_and_PID_forms.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -579,15 +475,7 @@ class autonicstk(instrument):
 
     def add_channel_sensor_type(self, channel_name):
         """Add a channel sensor type.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
         """
@@ -626,15 +514,7 @@ class autonicstk(instrument):
 
     def add_channels_alarm_config(self, channel_name):
         """Add a channels alarm config.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
         """

--- a/PyICe/lab_instruments/bk8500.py
+++ b/PyICe/lab_instruments/bk8500.py
@@ -118,14 +118,8 @@ class bk8500(instrument):
 
     def add_channel_current(self, channel_name):
         """Add single CC forcing channel and force zero current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
 
@@ -143,15 +137,7 @@ class bk8500(instrument):
 
     def add_channel_isense(self, channel_name):
         """Add single current readback channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -167,15 +153,7 @@ class bk8500(instrument):
 
     def add_channel_vsense(self, channel_name):
         """Add single voltage readback channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -191,15 +169,7 @@ class bk8500(instrument):
 
     def add_channel_psense(self, channel_name):
         """Read back computed power dissipated in load.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -215,15 +185,7 @@ class bk8500(instrument):
 
     def add_channel_mode(self, channel_name):
         """Read back operating mode (Off, Constant Current, Constant Voltage, Constant Power, Constant Resistance).
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -279,14 +241,8 @@ class bk8500(instrument):
 
     def add_channel_remote_sense(self, channel_name):
         """Enable/disable remote voltage sense through rear panel connectors.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
 
@@ -302,15 +258,7 @@ class bk8500(instrument):
 
     def add_channel_voltage(self, channel_name):
         """Add single CV forcing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -325,15 +273,7 @@ class bk8500(instrument):
 
     def add_channel_power(self, channel_name):
         """Add single CW forcing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -348,15 +288,7 @@ class bk8500(instrument):
 
     def add_channel_resistance(self, channel_name):
         """Add single CR forcing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/bk8600.py
+++ b/PyICe/lab_instruments/bk8600.py
@@ -32,15 +32,7 @@ class bk8600(scpi_instrument):
 
     def add_channel(self, channel_name, add_extended_channels=True):
         """Helper channel adds primary current forcing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             add_extended_channels: If True, add sense and mode channels.
             channel_name: Name for the new channel.
@@ -64,15 +56,7 @@ class bk8600(scpi_instrument):
 
     def add_channel_voltage(self, channel_name):
         """Add single CV forcing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -87,15 +71,7 @@ class bk8600(scpi_instrument):
 
     def add_channel_vsense(self, channel_name):
         """Add output voltage reading channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -110,15 +86,7 @@ class bk8600(scpi_instrument):
 
     def add_channel_current(self, channel_name):
         """Add single CC forcing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -133,15 +101,7 @@ class bk8600(scpi_instrument):
 
     def add_channel_isense(self, channel_name):
         """Add output current reading channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -156,15 +116,7 @@ class bk8600(scpi_instrument):
 
     def add_channel_power(self, channel_name):
         """Add single CW forcing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -179,15 +131,7 @@ class bk8600(scpi_instrument):
 
     def add_channel_psense(self, channel_name):
         """Add output power reading channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -202,15 +146,7 @@ class bk8600(scpi_instrument):
 
     def add_channel_mode(self, channel_name):
         """Add a channel mode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -222,14 +158,8 @@ class bk8600(scpi_instrument):
 
     def add_channel_remote_sense(self, channel_name):
         """Enable/disable remote voltage sense through rear panel connectors.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/chroma_63600.py
+++ b/PyICe/lab_instruments/chroma_63600.py
@@ -67,15 +67,7 @@ class chroma_63600(scpi_instrument):
 
     def add_channel_current(self, channel_name, num):
         """Add a channel current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -99,15 +91,7 @@ class chroma_63600(scpi_instrument):
 
     def add_channel_voltage(self, channel_name, num):
         """Add a channel voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -132,15 +116,7 @@ class chroma_63600(scpi_instrument):
     # current limit in CV  mode
     def add_channel_current_limit(self, channel_name, num):
         """Add a channel current limit.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -164,15 +140,7 @@ class chroma_63600(scpi_instrument):
 
     def add_channel_resistance(self, channel_name, num):
         """Add a channel resistance.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -198,15 +166,7 @@ class chroma_63600(scpi_instrument):
 
     def add_channel_power(self, channel_name, num):
         """Add a channel power.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -234,15 +194,7 @@ class chroma_63600(scpi_instrument):
 
     def add_channel_measured_current(self, channel_name, num):
         """Add a channel measured current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -264,15 +216,7 @@ class chroma_63600(scpi_instrument):
 
     def add_channel_measured_voltage(self, channel_name, num):
         """Add a channel measured voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -295,15 +239,7 @@ class chroma_63600(scpi_instrument):
 
     def add_channel_measured_power(self, channel_name, num):
         """Add a channel measured power.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.

--- a/PyICe/lab_instruments/daq970a_instruments.py
+++ b/PyICe/lab_instruments/daq970a_instruments.py
@@ -325,15 +325,7 @@ class agilent_a970a_20ch_40ch(daq970a_instrument):
     def add_channel_dc_voltage(self, channel_name, channel_num, NPLC=1, range="AUTO",
                                high_z=True, delay=None, disable_autozero=True, Rsource=None):
         """Shortcut method to add voltage channel and configure in one step.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new voltage channel.
             channel_num: Physical channel number on the mux.
@@ -382,15 +374,7 @@ class agilent_a970a_20ch_40ch(daq970a_instrument):
     def add_channel_thermocouple(
             self, channel_name, channel_num, tcouple_type, NPLC=1, disable_autozero=True):
         """Shortcut method to add thermistor measurement channel and configure in one step.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new thermocouple channel.
             channel_num: Physical channel number on the mux.
@@ -551,14 +535,8 @@ class agilent_a970a_20ch_40ch(daq970a_instrument):
 
     def add_channel_nplc(self, channel_name, base_channel):
         """Adds a secondary channel that can modify the nplc setting of an existing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new NPLC control channel.
             base_channel: The measurement channel whose NPLC to modify.
@@ -581,14 +559,8 @@ class agilent_a970a_20ch_40ch(daq970a_instrument):
 
     def add_channel_delay(self, channel_name, base_channel):
         """Adds a secondary channel that can modify the delay of an existing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new delay control channel.
             base_channel: The measurement channel whose delay to modify.
@@ -668,14 +640,8 @@ class agilent_a970a_20ch_40ch(daq970a_instrument):
 
     def add_channel_range_readback(self, channel_name, base_channel):
         """Add a channel that reads back the current voltage range setting.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``SENSe:VOLTage:DC:RANGe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new range readback channel.
             base_channel: The measurement channel to read range from.
@@ -689,14 +655,8 @@ class agilent_a970a_20ch_40ch(daq970a_instrument):
 
     def add_channel_gain(self, channel_name, base_channel):
         """Adds a secondary channel that can modify the gain (span multiplier) of an existing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new gain control channel.
             base_channel: The measurement channel whose gain to modify.
@@ -724,14 +684,8 @@ class agilent_a970a_20ch_40ch(daq970a_instrument):
 
     def add_channel_offset(self, channel_name, base_channel):
         """Adds a secondary channel that can modify the offset of an existing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new offset control channel.
             base_channel: The measurement channel whose offset to modify.
@@ -759,14 +713,8 @@ class agilent_a970a_20ch_40ch(daq970a_instrument):
 
     def add_channel_unit(self, channel_name, base_channel):
         """Adds a secondary channel that can modify the displayed unit (V/A/etc) of an existing channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new unit control channel.
             base_channel: The measurement channel whose display unit to modify.
@@ -826,15 +774,7 @@ class agilent_a970a_20ch(agilent_a970a_20ch_40ch):
     def add_channel_dc_current(self, channel_name, channel_num,
                                NPLC=1, range='AUTO', delay=None, disable_autozero=True):
         """DC current measurement only allowed on 34901A channels 21 and 22.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new current channel.
             channel_num: Physical channel number (must be 21 or 22).
@@ -883,14 +823,8 @@ class agilent_a970a_20ch(agilent_a970a_20ch_40ch):
 
     def add_channel_ammeter_range(self, channel_name, base_channel):
         """Modify ammeter current range shunt.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new range control channel.
             base_channel: The current measurement channel whose range to modify.
@@ -1054,15 +988,7 @@ class agilent_a970a_dacs(daq970a_instrument):
 
     def add_channel(self, channel_name, channel_num):
         """Add named DAC channel to instrument.  num is 1-2, mapping to physical channel 4-5.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new DAC channel.
             channel_num: DAC number (1 or 2), mapping to physical channel 4-5.
@@ -1090,7 +1016,6 @@ class agilent_a970a_dacs(daq970a_instrument):
         """Set named DAC to voltage.  Range is +/-12V with 16bit (366uV) resolution.
         Formats and sends the command to the instrument.
         Sends the ``SOURCE:VOLT`` SCPI command to the instrument.
-        Formats and sends the command to the instrument.
 
         Sends the corresponding SCPI command string to the instrument over the bus.
 
@@ -1134,15 +1059,7 @@ class agilent_a970a_actuator(daq970a_instrument):
 
     def add_channel(self, channel_name, channel_num):
         """Channel_num is 1-20.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new relay channel.
             channel_num: Physical channel number (1-20).

--- a/PyICe/lab_instruments/data_precision_8200.py
+++ b/PyICe/lab_instruments/data_precision_8200.py
@@ -100,15 +100,7 @@ class data_precision_8200(instrument):
 
     def add_channel_mode(self, channel_name):
         """Channel returns 'V' when in Voltage mode and 'A' when in current mode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/firmata.py
+++ b/PyICe/lab_instruments/firmata.py
@@ -272,15 +272,7 @@ class firmata(instrument):
 
     def add_channel_analog_input(self, channel_name, pin):
         """Analog input pin.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             pin: Pin number.
@@ -374,7 +366,6 @@ class firmata(instrument):
         """RC servo control (544ms-2400ms PWM) output.
 
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             pin: Pin number.

--- a/PyICe/lab_instruments/fluke_45.py
+++ b/PyICe/lab_instruments/fluke_45.py
@@ -71,15 +71,7 @@ class fluke_45(scpi_instrument):
 
     def add_channel(self, channel_name):
         """Add named channel to instrument without configuring measurement type.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/fluke_8845.py
+++ b/PyICe/lab_instruments/fluke_8845.py
@@ -107,15 +107,7 @@ class fluke_8845(scpi_instrument):
 
     def add_channel(self, channel_name):
         """Add named channel to instrument without configuring measurement type.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/hameg_4040.py
+++ b/PyICe/lab_instruments/hameg_4040.py
@@ -102,15 +102,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_voltage(self, channel_name, num):
         """Add a channel voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -131,15 +123,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_current(self, channel_name, num):
         """Add a channel current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -160,15 +144,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_vsense(self, channel_name, num):
         """Add a channel vsense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -183,15 +159,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_isense(self, channel_name, num):
         """Add a channel isense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -206,15 +174,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_voltage_readback(self, channel_name, num):
         """Add a channel voltage readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -230,15 +190,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_current_readback(self, channel_name, num):
         """Add a channel current readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -254,15 +206,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_measured_voltage(self, channel_name, num):
         """Add a channel measured voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -278,15 +222,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_measured_current(self, channel_name, num):
         """Add a channel measured current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -302,15 +238,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_ovp(self, channel_name, num):
         """Add a channel ovp.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -328,15 +256,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_ovp_status(self, channel_name, num):
         """Add a channel ovp status.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -353,15 +273,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_fuse_status(self, channel_name, num):
         """Add a channel fuse status.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -378,15 +290,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_enable(self, channel_name, num):
         """Add a channel enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -405,15 +309,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_fuse_enable(self, channel_name, num, fuse_delay=0):
         """Add a channel fuse enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             fuse_delay: Fuse delay to use.
@@ -435,15 +331,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_fuse_link(self, channel_name, num):
         """Add a channel fuse link.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.
@@ -462,15 +350,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_master_enable(self, channel_name):
         """Add a channel master enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -484,15 +364,7 @@ class hameg_4040(scpi_instrument):
 
     def add_channel_AWG(self, channel_name, num):
         """Add a channel AWG.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             num: Count or number.

--- a/PyICe/lab_instruments/hp_3478a.py
+++ b/PyICe/lab_instruments/hp_3478a.py
@@ -55,15 +55,7 @@ class hp_3478a(instrument):
 
     def add_channel(self, channel_name):
         """Add named channel to instrument without configuring measurement type.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/hp_4155b.py
+++ b/PyICe/lab_instruments/hp_4155b.py
@@ -94,15 +94,7 @@ class hp_4155b(semiconductor_parameter_analyzer):
     def add_channels_smu_voltage(
             self, smu_number, voltage_force_channel_name, current_compliance_channel_name):
         """Add a channels smu voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             current_compliance_channel_name: Current compliance channel name to use.
             smu_number: Source-measure unit channel number (1-based).
@@ -118,15 +110,7 @@ class hp_4155b(semiconductor_parameter_analyzer):
     def add_channel_smu_voltage_output_range(
             self, smu_number, output_range_channel_name):
         """Add a channel smu voltage output range.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             output_range_channel_name: Output range channel name to use.
             smu_number: Source-measure unit channel number (1-based).
@@ -141,15 +125,7 @@ class hp_4155b(semiconductor_parameter_analyzer):
     def add_channels_smu_current(
             self, smu_number, current_force_channel_name, voltage_compliance_channel_name):
         """Add a channels smu current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             current_force_channel_name: Current force channel name to use.
             smu_number: Source-measure unit channel number (1-based).
@@ -165,15 +141,7 @@ class hp_4155b(semiconductor_parameter_analyzer):
     def add_channel_smu_current_output_range(
             self, smu_number, output_range_channel_name):
         """Add a channel smu current output range.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             output_range_channel_name: Output range channel name to use.
             smu_number: Source-measure unit channel number (1-based).
@@ -188,15 +156,7 @@ class hp_4155b(semiconductor_parameter_analyzer):
     def add_channel_smu_voltage_sense(
             self, smu_number, voltage_sense_channel_name):
         """Add a channel smu voltage sense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             smu_number: Source-measure unit channel number (1-based).
             voltage_sense_channel_name: Voltage sense channel name to use.
@@ -211,15 +171,7 @@ class hp_4155b(semiconductor_parameter_analyzer):
     def add_channel_smu_current_sense(
             self, smu_number, current_sense_channel_name):
         """Add a channel smu current sense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             current_sense_channel_name: Current sense channel name to use.
             smu_number: Source-measure unit channel number (1-based).
@@ -233,15 +185,7 @@ class hp_4155b(semiconductor_parameter_analyzer):
 
     def add_channel_vsource(self, vsource_number, vsource_channel_name):
         """Add a channel vsource.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             vsource_channel_name: Vsource channel name to use.
             vsource_number: Vsource number to use.
@@ -254,15 +198,7 @@ class hp_4155b(semiconductor_parameter_analyzer):
 
     def add_channel_vmeter(self, vmeter_number, vmeter_channel_name):
         """Add a channel vmeter.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             vmeter_channel_name: Vmeter channel name to use.
             vmeter_number: Vmeter number to use.

--- a/PyICe/lab_instruments/htx9000.py
+++ b/PyICe/lab_instruments/htx9000.py
@@ -57,15 +57,7 @@ class htx9000(scpi_instrument):
 
     def add_channel_current(self, channel_name):
         """Add a channel current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -92,15 +84,7 @@ class htx9000(scpi_instrument):
 
     def add_channel_current_readback(self, channel_name):
         """Add a channel current readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -113,15 +97,7 @@ class htx9000(scpi_instrument):
 
     def add_channel_dropout(self, channel_name):
         """Add a channel dropout.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -136,15 +112,7 @@ class htx9000(scpi_instrument):
 
     def add_channel_temp_heatsink(self, channel_name):
         """Add a channel temp heatsink.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -157,15 +125,7 @@ class htx9000(scpi_instrument):
 
     def add_channel_temp_board(self, channel_name):
         """Add a channel temp board.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -179,15 +139,7 @@ class htx9000(scpi_instrument):
 
     def add_channel_swipepad_lock(self, channel_name):
         """Add a channel swipepad lock.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -203,15 +155,7 @@ class htx9000(scpi_instrument):
 
     def add_channel_manual_range(self, channel_name):
         """Add a channel manual range.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -228,14 +172,8 @@ class htx9000(scpi_instrument):
 
     def add_channel_range_readback(self, channel_name):
         """Add a channel range readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SOURce:CURRent:RANGe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -408,15 +346,7 @@ class htx9000SE_5A(htx9000):
 
     def add_channel_current(self, channel_name):
         """Add a channel current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/htx9001.py
+++ b/PyICe/lab_instruments/htx9001.py
@@ -75,15 +75,7 @@ class htx9001(scpi_instrument):
 
     def add_channel_dvcc(self, channel_name):
         """Adds a channel controlling the dvcc voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/htx9001a.py
+++ b/PyICe/lab_instruments/htx9001a.py
@@ -176,15 +176,7 @@ class htx9001a(htx9001):
 
     def add_channel_pwm(self, channel_name, pin):
         """Add a channel pwm.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             pin: Pin number.
@@ -318,15 +310,7 @@ class htx9001a(htx9001):
 
     def add_channel_servo(self, channel_name, servo_number):
         """Add a channel servo.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             servo_number: Servo number to use.
@@ -356,15 +340,7 @@ class htx9001a(htx9001):
 
     def add_channel_servo_enable(self, channel_name, servo_number):
         """Add a channel servo enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             servo_number: Servo number to use.

--- a/PyICe/lab_instruments/htx9011.py
+++ b/PyICe/lab_instruments/htx9011.py
@@ -121,15 +121,7 @@ class htx9011(scpi_instrument):
 
     def add_channel_dvcc(self, channel_name):
         """Adds a channel controlling the dvcc voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -183,15 +175,7 @@ class htx9011(scpi_instrument):
 
     def add_channel_master_relay_bias(self, channel_name):
         """Adds a Master Relay Arm Channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -308,15 +292,7 @@ class htx9011(scpi_instrument):
 
     def add_channel_range(self, channel_name, channel_number):
         """Add a channel range.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -840,15 +816,7 @@ class htx9011(scpi_instrument):
 
     def add_channel_pwm(self, channel_name, pin):
         """Add a channel pwm.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             pin: Pin number.
@@ -983,15 +951,7 @@ class htx9011(scpi_instrument):
 
     def add_channel_servo(self, channel_name, servo_number):
         """Add a channel servo.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             servo_number: Servo number to use.
@@ -1020,15 +980,7 @@ class htx9011(scpi_instrument):
 
     def add_channel_servo_enable(self, channel_name, servo_number):
         """Add a channel servo enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             servo_number: Servo number to use.
@@ -1051,14 +1003,8 @@ class htx9011(scpi_instrument):
 
     def add_channel_interrupt(self, channel_name, interrupt_number):
         """Add a channel interrupt.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             interrupt_number: Interrupt number to use.
@@ -1132,14 +1078,8 @@ class htx9011(scpi_instrument):
 
     def add_channel_pcint(self, channel_name, pcint_number):
         """Control channel for each PCINT. Silently creates captured value channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             pcint_number: Pcint number to use.
@@ -1528,15 +1468,7 @@ class PCF8574_on_ConfiguratorXT(instrument):
 
     def add_channel_covering_all_pins(self, channel_name):
         """Add a channel covering all pins.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/htx9016.py
+++ b/PyICe/lab_instruments/htx9016.py
@@ -45,14 +45,8 @@ class htx9016(scpi_instrument):
 
     def add_channel(self, channel_name):
         """Add a channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SELEct:CHANnel`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/hypertronix_powermux.py
+++ b/PyICe/lab_instruments/hypertronix_powermux.py
@@ -29,15 +29,7 @@ class powermux(scpi_instrument):
 
     def add_channel_relay_names(self, channel_name, column_name, row_name):
         """Add a channel relay names.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             column_name: Name of the database column.
@@ -53,15 +45,7 @@ class powermux(scpi_instrument):
 
     def add_channel_relay(self, channel_name, column_number, row_number):
         """Add a channel relay.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             column_number: Column number to use.

--- a/PyICe/lab_instruments/keithley_4200.py
+++ b/PyICe/lab_instruments/keithley_4200.py
@@ -183,11 +183,7 @@ class keithley_4200(semiconductor_parameter_analyzer):
             self, smu_number, voltage_force_channel_name, current_compliance_channel_name):
         # check smu_number is valid
         """Add a channels smu voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             current_compliance_channel_name: Current compliance channel name to use.
             smu_number: Source-measure unit channel number (1-based).
@@ -203,11 +199,7 @@ class keithley_4200(semiconductor_parameter_analyzer):
             self, smu_number, output_range_channel_name):
         # check smu_number is valid
         """Add a channel smu voltage output range.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             output_range_channel_name: Output range channel name to use.
             smu_number: Source-measure unit channel number (1-based).
@@ -222,11 +214,7 @@ class keithley_4200(semiconductor_parameter_analyzer):
             self, smu_number, current_force_channel_name, voltage_compliance_channel_name):
         # check smu_number is valid
         """Add a channels smu current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             current_force_channel_name: Current force channel name to use.
             smu_number: Source-measure unit channel number (1-based).
@@ -242,11 +230,7 @@ class keithley_4200(semiconductor_parameter_analyzer):
             self, smu_number, output_range_channel_name):
         # check smu_number is valid
         """Add a channel smu current output range.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             output_range_channel_name: Output range channel name to use.
             smu_number: Source-measure unit channel number (1-based).
@@ -261,11 +245,7 @@ class keithley_4200(semiconductor_parameter_analyzer):
             self, smu_number, voltage_sense_channel_name):
         # check smu_number is valid
         """Add a channel smu voltage sense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             smu_number: Source-measure unit channel number (1-based).
             voltage_sense_channel_name: Voltage sense channel name to use.
@@ -280,11 +260,7 @@ class keithley_4200(semiconductor_parameter_analyzer):
             self, smu_number, current_sense_channel_name):
         # check smu_number is valid
         """Add a channel smu current sense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             current_sense_channel_name: Current sense channel name to use.
             smu_number: Source-measure unit channel number (1-based).
@@ -298,11 +274,7 @@ class keithley_4200(semiconductor_parameter_analyzer):
     def add_channel_vsource(self, vsource_number, vsource_channel_name):
         # check vsource_number is valid
         """Add a channel vsource.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             vsource_channel_name: Vsource channel name to use.
             vsource_number: Vsource number to use.
@@ -315,11 +287,7 @@ class keithley_4200(semiconductor_parameter_analyzer):
     def add_channel_vmeter(self, vmeter_number, vmeter_channel_name):
         # check vmeter_number is valid
         """Add a channel vmeter.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             vmeter_channel_name: Vmeter channel name to use.
             vmeter_number: Vmeter number to use.

--- a/PyICe/lab_instruments/keysight_u2300a.py
+++ b/PyICe/lab_instruments/keysight_u2300a.py
@@ -116,15 +116,7 @@ class u2300a_scope(scpi_instrument, delegator):
 
     def add_channel_timeout(self, channel_name):
         """Add trigger timeout control channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -144,15 +136,7 @@ class u2300a_scope(scpi_instrument, delegator):
 
     def add_channel_time(self, channel_name):
         """Add timebase readback channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -443,15 +427,7 @@ class u2300a_scope(scpi_instrument, delegator):
 
     def add_channels_trigger(self, base_name):
         """Channel-ize options otherwise availabe from set_trigger() method. Unclear if there's a required order of operations that complicates this process. Untested.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             base_name: Root name for file or channel generation.
 
@@ -673,15 +649,7 @@ class u2300a_scope(scpi_instrument, delegator):
 
     def add_channel_acquisition_time(self, name):
         """Channel-ize option otherwise availabe from set_acquisition_time() method.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             name: Name identifier.
         """
@@ -726,15 +694,7 @@ class u2300a_scope(scpi_instrument, delegator):
 
     def add_channel_sample_rate(self, name):
         """Channel-ize option otherwise availabe from set_sample_rate() method.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             name: Name identifier.
         """

--- a/PyICe/lab_instruments/kikusui_pbz.py
+++ b/PyICe/lab_instruments/kikusui_pbz.py
@@ -68,15 +68,7 @@ class kikusui_pbz(scpi_instrument):
 
     def add_channel_voltage(self, channel_name):
         """Add a channel voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -88,15 +80,7 @@ class kikusui_pbz(scpi_instrument):
 
     def add_channel_current_source(self, channel_name):
         """Add a channel current source.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -109,15 +93,7 @@ class kikusui_pbz(scpi_instrument):
 
     def add_channel_current_sink(self, channel_name):
         """Add a channel current sink.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -130,15 +106,7 @@ class kikusui_pbz(scpi_instrument):
 
     def add_channel_output_enable(self, channel_name):
         """Add a channel output enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -151,15 +119,7 @@ class kikusui_pbz(scpi_instrument):
 
     def add_channel_vsense(self, channel_name):
         """Add a channel vsense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -171,15 +131,7 @@ class kikusui_pbz(scpi_instrument):
 
     def add_channel_isense(self, channel_name):
         """Add a channel isense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -191,15 +143,7 @@ class kikusui_pbz(scpi_instrument):
 
     def add_channel_voltage_readback(self, channel_name):
         """Add a channel voltage readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/kikusui_plz.py
+++ b/PyICe/lab_instruments/kikusui_plz.py
@@ -52,15 +52,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel(self, channel_name, add_sense_channels=True):
         """Helper function adds primary current forcing channel of channel_name plus _vsense and _isense readback channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             add_sense_channels: Add sense channels to use.
             channel_name: Name for the new channel.
@@ -75,15 +67,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_current(self, channel_name):
         """Add a channel current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -92,15 +76,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_voltage(self, channel_name):
         """Add a channel voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -109,15 +85,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_vsense(self, channel_name):
         """Add a channel vsense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -126,15 +94,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_isense(self, channel_name):
         """Add a channel isense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -143,15 +103,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_power(self, channel_name):
         """Add a channel power.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -160,15 +112,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_range_readback(self, channel_name):
         """Add a channel range readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -177,15 +121,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_range(self, channel_name):
         """Add a channel range.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -194,15 +130,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_slew_rate(self, channel_name):
         """Add a channel slew rate.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -212,15 +140,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_pulse_on(self, channel_name):
         """Add a channel pulse on.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -232,15 +152,7 @@ class kikusui_plz(scpi_instrument):
     # Duty cycle, frequency and current level are used for Switch operation
     def add_channel_duty_cycle(self, channel_name):
         """Add a channel duty cycle.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -250,15 +162,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_frequency(self, channel_name):
         """Add a channel frequency.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -268,15 +172,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_current_level(self, channel_name):
         """Add a channel current level.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -290,15 +186,7 @@ class kikusui_plz(scpi_instrument):
         # Remember to input a high current in your own code to force the change
         # in Range
         """Add a channel short.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -307,15 +195,7 @@ class kikusui_plz(scpi_instrument):
 
     def add_channel_enable(self, channel_name):
         """Add a channel enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """

--- a/PyICe/lab_instruments/kikusui_pwr.py
+++ b/PyICe/lab_instruments/kikusui_pwr.py
@@ -79,15 +79,7 @@ class kikusui_pwr(scpi_instrument):
 
     def add_channel_voltage(self, channel_name):
         """Add a channel voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -99,15 +91,7 @@ class kikusui_pwr(scpi_instrument):
 
     def add_channel_current(self, channel_name):
         """Add a channel current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -119,15 +103,7 @@ class kikusui_pwr(scpi_instrument):
 
     def add_channel_vsense(self, channel_name):
         """Add a channel vsense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -139,15 +115,7 @@ class kikusui_pwr(scpi_instrument):
 
     def add_channel_isense(self, channel_name):
         """Add a channel isense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -159,15 +127,7 @@ class kikusui_pwr(scpi_instrument):
 
     def add_channel_power(self, channel_name):
         """Add a channel power.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -179,15 +139,7 @@ class kikusui_pwr(scpi_instrument):
 
     def add_channel_enable(self, channel_name):
         """Add a channel enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/krohnhite_523.py
+++ b/PyICe/lab_instruments/krohnhite_523.py
@@ -48,15 +48,7 @@ class krohnhite_523(instrument):
 
     def add_channel_voltage(self, channel_name):
         """Add a channel voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -68,15 +60,7 @@ class krohnhite_523(instrument):
 
     def add_channel_current(self, channel_name):
         """Add a channel current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -88,15 +72,7 @@ class krohnhite_523(instrument):
 
     def add_channel_voltage_compliance(self, channel_name):
         """Add a channel voltage compliance.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/krohnhite_526.py
+++ b/PyICe/lab_instruments/krohnhite_526.py
@@ -58,15 +58,7 @@ class krohnhite_526(instrument):
 
     def add_channel_current(self, channel_name):
         """Write channel to switch instrument to current mode and program current. Default current range is +/-10mA.  Create a irange channel to adjust range to (10, 100)mA.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -81,15 +73,7 @@ class krohnhite_526(instrument):
 
     def add_channel_irange(self, channel_name):
         """Write channel to set current mode full scale range to +/-(10,100)mA.  Won't take effect until the current is programmed.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -138,15 +122,7 @@ class krohnhite_526(instrument):
 
     def add_channel_voltage(self, channel_name):
         """Add a channel voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -161,15 +137,7 @@ class krohnhite_526(instrument):
 
     def add_channel_vrange(self, channel_name):
         """Write channel to set voltage mode full scale range to +/-(0.1,1,10,100)V or +/-(10,100)mA.  Won't take effect until the voltage is programmed.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/manual_oven.py
+++ b/PyICe/lab_instruments/manual_oven.py
@@ -26,15 +26,7 @@ class manual_oven(temperature_chamber, instrument_humanoid):
 
     def add_channels(self, channel_name):
         """Add a channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/modbus_relay.py
+++ b/PyICe/lab_instruments/modbus_relay.py
@@ -37,15 +37,7 @@ class modbus_relay(instrument):
 
     def add_channel_relay1(self, channel_name='relay1'):
         """Add a channel relay1.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -68,15 +60,7 @@ class modbus_relay(instrument):
 
     def add_channel_relay2(self, channel_name='relay2'):
         """Add a channel relay2.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument and maps it to the underlying device register for read/write access.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/oscilloscope.py
+++ b/PyICe/lab_instruments/oscilloscope.py
@@ -269,7 +269,6 @@ class oscilloscope(scpi_instrument, delegator):
         """Add time channel that stores the x-axis data points in seconds.
 
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             name: Name identifier.
         """

--- a/PyICe/lab_instruments/pyice_arduino_tool.py
+++ b/PyICe/lab_instruments/pyice_arduino_tool.py
@@ -254,7 +254,6 @@ class pyice_arduino_tool(instrument):
         def write_magic(message):
             """Perform write magic operation.
             Formats and sends the command to the instrument.
-            Formats and sends the command to the instrument.
 
             Writes data to the underlying target.
 
@@ -278,7 +277,6 @@ class pyice_arduino_tool(instrument):
     def _add_write_channel(self, channel_name, command):
         def write_jumbo(message):
             """Perform write jumbo operation.
-            Formats and sends the command to the instrument.
             Formats and sends the command to the instrument.
 
             Writes data to the underlying target.
@@ -1102,7 +1100,6 @@ class pyice_arduino_tool(instrument):
     def write_chip(self, command_code, write_data):
         """Return write chip result.
         Formats and sends the command to the instrument.
-        Formats and sends the command to the instrument.
 
         Writes data to the underlying target.
 
@@ -1175,7 +1172,6 @@ class pyice_arduino_tool(instrument):
 
     def write_pin(self, pin_num, pin_edge):
         """Perform write pin operation.
-        Formats and sends the command to the instrument.
         Formats and sends the command to the instrument.
 
         Writes data to the underlying target.
@@ -1379,15 +1375,7 @@ class pyice_arduino_tool(instrument):
 
     def add_channel_pin_control(self, channel_name, pin_num):
         """Add a channel pin control.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             pin_num: GPIO pin number (zero-based).
@@ -1422,15 +1410,7 @@ class pyice_arduino_tool(instrument):
     def add_channels_pwm(self, logger_instance,
                          channel_name, pin_num, pwm_freq):
         """Add a channels pwm.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             logger_instance: Logger instance to use.

--- a/PyICe/lab_instruments/relay.py
+++ b/PyICe/lab_instruments/relay.py
@@ -17,7 +17,6 @@ class relay(instrument):
         """Placeholder.
 
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -85,15 +84,7 @@ class ftdi_relay(relay):
 
     def add_channel(self, channel_name, channel_number):
         """Adds a channel for a relay on the board.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.

--- a/PyICe/lab_instruments/rigol_DG800.py
+++ b/PyICe/lab_instruments/rigol_DG800.py
@@ -33,15 +33,7 @@ class rigol_DG800(scpi_instrument):
     def add_channel(self, channel_name, channel_number,
                     function="PULSe", add_extended_channels=True):
         """Add a channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             add_extended_channels: If True, add sense and mode channels.
             channel_name: Name for the new channel.
@@ -163,15 +155,7 @@ class rigol_DG800(scpi_instrument):
 
     def add_channel_enable(self, channel_name, channel_number):
         """Add a channel enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -190,15 +174,7 @@ class rigol_DG800(scpi_instrument):
 
     def add_channel_low_voltage(self, channel_name, channel_number):
         """Add a channel low voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -216,15 +192,7 @@ class rigol_DG800(scpi_instrument):
 
     def add_channel_high_voltage(self, channel_name, channel_number):
         """Add a channel high voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -242,15 +210,7 @@ class rigol_DG800(scpi_instrument):
 
     def add_channel_pulse_width(self, channel_name, channel_number):
         """Add a channel pulse width.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -269,15 +229,7 @@ class rigol_DG800(scpi_instrument):
 
     def add_channel_pulse_period(self, channel_name, channel_number):
         """Add a channel pulse period.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -295,15 +247,7 @@ class rigol_DG800(scpi_instrument):
 
     def add_channel_rise_time(self, channel_name, channel_number):
         """Add a channel rise time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -322,15 +266,7 @@ class rigol_DG800(scpi_instrument):
 
     def add_channel_fall_time(self, channel_name, channel_number):
         """Add a channel fall time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -349,15 +285,7 @@ class rigol_DG800(scpi_instrument):
 
     def add_channel_trigger(self, channel_name, channel_number):
         """Add a channel trigger.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -374,15 +302,7 @@ class rigol_DG800(scpi_instrument):
 
     def add_channel_cycle_count(self, channel_name, channel_number):
         """Add a channel cycle count.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.

--- a/PyICe/lab_instruments/semiconductor_parameter_analyzer.py
+++ b/PyICe/lab_instruments/semiconductor_parameter_analyzer.py
@@ -277,15 +277,7 @@ class semiconductor_parameter_analyzer(scpi_instrument):
 
     def add_channel_integration_time(self, integration_time_channel_name):
         """Add a channel integration time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             integration_time_channel_name: Integration time channel name to use.
 

--- a/PyICe/lab_instruments/siglent_SDG1000X.py
+++ b/PyICe/lab_instruments/siglent_SDG1000X.py
@@ -84,15 +84,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burst(self, channel_name, channel_number):
         """Add a channel burst.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -137,15 +129,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_continuous(self, channel_name, channel_number):
         """Add a channel continuous.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -197,15 +181,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_enable(self, channel_name, channel_number):
         """Add a channel enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -228,15 +204,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_outputz(self, channel_name, channel_number):
         """Add a channel outputz.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -263,15 +231,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_DC(self, channel_name, channel_number):
         """Add a channel DC.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -293,15 +253,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_gate_ncyc(self, channel_name, channel_number):
         """Add a channel burstwave gate ncyc.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -322,15 +274,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_state(self, channel_name, channel_number):
         """Add a channel burstwave state.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -352,15 +296,7 @@ class siglent_SDG1000X(scpi_instrument):
     def add_channel_burstwave_trigger_source(
             self, channel_name, channel_number):
         """Add a channel burstwave trigger source.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -385,15 +321,7 @@ class siglent_SDG1000X(scpi_instrument):
     def add_channel_burstwave_trigger_out_mode(
             self, channel_name, channel_number):
         """Add a channel burstwave trigger out mode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -417,15 +345,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_cycles(self, channel_name, channel_number):
         """Add a channel burstwave cycles.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -448,15 +368,7 @@ class siglent_SDG1000X(scpi_instrument):
     def add_channel_burstwave_trigger_delay(
             self, channel_name, channel_number):
         """Add a channel burstwave trigger delay.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -477,15 +389,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_shape(self, channel_name, channel_number):
         """Add a channel burstwave shape.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -522,15 +426,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_low_voltage(self, channel_name, channel_number):
         """Add a channel burstwave low voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -551,15 +447,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_high_voltage(self, channel_name, channel_number):
         """Add a channel burstwave high voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -580,15 +468,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_pulse_width(self, channel_name, channel_number):
         """Add a channel burstwave pulse width.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -614,15 +494,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_period(self, channel_name, channel_number):
         """Add a channel burstwave period.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -644,15 +516,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_rise_time(self, channel_name, channel_number):
         """Add a channel burstwave rise time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -675,15 +539,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_fall_time(self, channel_name, channel_number):
         """Add a channel burstwave fall time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -706,15 +562,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_delay(self, channel_name, channel_number):
         """Add a channel burstwave delay.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -735,15 +583,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_burstwave_trigger(self, channel_name, channel_number):
         """Add a channel burstwave trigger.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -771,15 +611,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_continuouswave_shape(self, channel_name, channel_number):
         """Add a channel continuouswave shape.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -809,15 +641,7 @@ class siglent_SDG1000X(scpi_instrument):
     def add_channel_continuouswave_low_voltage(
             self, channel_name, channel_number):
         """Add a channel continuouswave low voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -839,15 +663,7 @@ class siglent_SDG1000X(scpi_instrument):
     def add_channel_continuouswave_high_voltage(
             self, channel_name, channel_number):
         """Add a channel continuouswave high voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -868,15 +684,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_continuouswave_width(self, channel_name, channel_number):
         """Add a channel continuouswave width.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -899,15 +707,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_continuouswave_period(self, channel_name, channel_number):
         """Add a channel continuouswave period.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -930,15 +730,7 @@ class siglent_SDG1000X(scpi_instrument):
     def add_channel_continuouswave_rise_time(
             self, channel_name, channel_number):
         """Add a channel continuouswave rise time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -962,15 +754,7 @@ class siglent_SDG1000X(scpi_instrument):
     def add_channel_continuouswave_fall_time(
             self, channel_name, channel_number):
         """Add a channel continuouswave fall time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -993,15 +777,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_phase_mode(self, channel_name):
         """Add a channel phase mode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -1024,15 +800,7 @@ class siglent_SDG1000X(scpi_instrument):
 
     def add_channel_sync_out(self, channel_name, channel_number):
         """Add a channel sync out.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.

--- a/PyICe/lab_instruments/smu.py
+++ b/PyICe/lab_instruments/smu.py
@@ -61,11 +61,7 @@ class smu(instrument):
 
     def add_channels(self, channel_name, channel_number=1):
         """Shortcut.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -89,15 +85,7 @@ class smu(instrument):
 
     def add_channel_voltage_force(self, channel_name, channel_number=1):
         """Voltage force. Mutually exclusive at any moment with current force.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -124,15 +112,7 @@ class smu(instrument):
 
     def add_channel_current_force(self, channel_name, channel_number=1):
         """Current force. Mutually exclusive at any moment with voltage force.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -159,15 +139,7 @@ class smu(instrument):
 
     def add_channel_voltage_sense(self, channel_name, channel_number=1):
         """Voltage readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -192,15 +164,7 @@ class smu(instrument):
 
     def add_channel_current_sense(self, channel_name, channel_number=1):
         """Current readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -225,15 +189,7 @@ class smu(instrument):
 
     def add_channel_voltage_compliance(self, channel_name, channel_number=1):
         """Max voltage in current forcing modes.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -261,15 +217,7 @@ class smu(instrument):
 
     def add_channel_current_compliance(self, channel_name, channel_number=1):
         """Max current in voltage forcing modes.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -297,15 +245,7 @@ class smu(instrument):
 
     def add_channel_remote_sense(self, channel_name, channel_number=1):
         """Remote (4-wire) sense enable control.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -335,15 +275,7 @@ class smu(instrument):
 
     def add_channel_high_capacitance(self, channel_name, channel_number):
         """Stabilize forcing source for higher DUT capacitance, typically tens of uF.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -373,15 +305,7 @@ class smu(instrument):
 
     def add_channel_terminal_select(self, channel_name, channel_number):
         """Select between front and rear panel terminals.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.

--- a/PyICe/lab_instruments/sorensen_generic_supply.py
+++ b/PyICe/lab_instruments/sorensen_generic_supply.py
@@ -53,15 +53,7 @@ class sorensen_generic_supply(instrument):
 
     def add_channel_voltage(self, channel_name):
         """Add a channel voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -73,15 +65,7 @@ class sorensen_generic_supply(instrument):
 
     def add_channel_current(self, channel_name):
         """Add a channel current.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -90,15 +74,7 @@ class sorensen_generic_supply(instrument):
 
     def add_channel_vsense(self, channel_name):
         """Add a channel vsense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """
@@ -107,15 +83,7 @@ class sorensen_generic_supply(instrument):
 
     def add_channel_isense(self, channel_name):
         """Add a channel isense.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
         """

--- a/PyICe/lab_instruments/sun_ec1x.py
+++ b/PyICe/lab_instruments/sun_ec1x.py
@@ -43,14 +43,8 @@ class sun_ec1x(sun_ecxx):
 
     def add_channel_user_sense(self, channel_name):
         """Channel_name represents secondary non-control thermocouple readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/tektronix_3054.py
+++ b/PyICe/lab_instruments/tektronix_3054.py
@@ -34,15 +34,7 @@ class tektronix_3054(scpi_instrument, delegator):
 
     def add_channel_time(self, channel_name):
         """Add a channel time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -57,15 +49,7 @@ class tektronix_3054(scpi_instrument, delegator):
 
     def add_channel(self, channel_name, scope_channel_number):
         """Add named channel to instrument.  num is 1-4.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             scope_channel_number: Oscilloscope channel number (1-based).
@@ -83,15 +67,7 @@ class tektronix_3054(scpi_instrument, delegator):
     def add_channel_dvm(self, channel_name,
                         scope_channel_number, measurement_time=2, mode='DC'):
         """Add a channel dvm.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             measurement_time: Measurement time to use.

--- a/PyICe/lab_instruments/tektronix_afg3022.py
+++ b/PyICe/lab_instruments/tektronix_afg3022.py
@@ -25,14 +25,8 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_burst(self, channel_name, channel_number):
         """Add a channel burst.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:BURSt:MODE`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -70,15 +64,7 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_continuous(self, channel_name, channel_number):
         """Add a channel continuous.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -132,14 +118,8 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_enable(self, channel_name, channel_number):
         """Add a channel enable.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:STATE`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:STATE`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -168,15 +148,9 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_outputz(self, channel_name, channel_number):
         """Add a channel outputz.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:VOLTage:LEVel:IMMediate:LOW`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -241,15 +215,9 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_burstwave_low_voltage(self, channel_name, channel_number):
         """Add a channel burstwave low voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:VOLTage:LEVel:IMMediate:LOW`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -270,15 +238,9 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_burstwave_high_voltage(self, channel_name, channel_number):
         """Add a channel burstwave high voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:VOLTage:LEVel:IMMediate:HIGH`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -299,14 +261,8 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_burstwave_pulse_width(self, channel_name, channel_number):
         """Add a channel burstwave pulse width.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PULSe:WIDTh`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -329,14 +285,8 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_burstwave_period(self, channel_name, channel_number):
         """Add a channel burstwave period.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PULSe:PERiod`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -357,14 +307,8 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_burstwave_pulse_hold(self, channel_name, channel_number):
         """Add a channel burstwave pulse hold.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PULSe:HOLD`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -387,15 +331,9 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_burstwave_rise_time(self, channel_name, channel_number):
         """Add a channel burstwave rise time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PULSe:TRANsition:LEADing`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -418,15 +356,9 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_burstwave_fall_time(self, channel_name, channel_number):
         """Add a channel burstwave fall time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PULSe:TRANsition:TRAiling`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -449,14 +381,8 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_burstwave_cycles(self, channel_name, channel_number):
         """Add a channel burstwave cycles.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:BURSt:NCYCles`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -477,15 +403,7 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_burstwave_trigger(self, channel_name, channel_number):
         """Sends trigger for all active channels regardless of channel_name or channel_number.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -541,15 +459,9 @@ class tektronix_afg3022(scpi_instrument):
     def add_channel_continuouswave_low_voltage(
             self, channel_name, channel_number):
         """Add a channel continuouswave low voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:VOLTage:LEVel:IMMediate:LOW`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -571,15 +483,9 @@ class tektronix_afg3022(scpi_instrument):
     def add_channel_continuouswave_high_voltage(
             self, channel_name, channel_number):
         """Add a channel continuouswave high voltage.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:VOLTage:LEVel:IMMediate:HIGH`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -600,14 +506,8 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_continuouswave_width(self, channel_name, channel_number):
         """Add a channel continuouswave width.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PULSe:WIDTh`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -630,14 +530,8 @@ class tektronix_afg3022(scpi_instrument):
 
     def add_channel_continuouswave_period(self, channel_name, channel_number):
         """Add a channel continuouswave period.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PULSe:PERiod`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -659,14 +553,8 @@ class tektronix_afg3022(scpi_instrument):
     def add_channel_continuouswave_pulse_hold(
             self, channel_name, channel_number):
         """Add a channel continuouswave pulse hold.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PULSe:HOLD`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -690,15 +578,9 @@ class tektronix_afg3022(scpi_instrument):
     def add_channel_continuouswave_rise_time(
             self, channel_name, channel_number):
         """Add a channel continuouswave rise time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PULSe:TRANsition:LEADing`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -722,15 +604,9 @@ class tektronix_afg3022(scpi_instrument):
     def add_channel_continuouswave_fall_time(
             self, channel_name, channel_number):
         """Add a channel continuouswave fall time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PULSe:TRANsition:TRAiling`` SCPI command to the
         instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.

--- a/PyICe/lab_instruments/tektronix_mso4104b.py
+++ b/PyICe/lab_instruments/tektronix_mso4104b.py
@@ -165,15 +165,7 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_time(self, channel_name):
         """Add a channel time.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -378,14 +370,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_probe_gain(self, channel_name, channel_number):
         """Add a channel probe gain.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:PRObe:GAIN`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -408,14 +394,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_BWLimit(self, channel_name, channel_number):
         """Available bandwidth limits vary by model and are also influenced by probes.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:BANdwidth`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:BANdwidth`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -447,14 +427,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_Yrange(self, channel_name, channel_number):
         """Range = Scale x 8?
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``:SCAle`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -477,14 +451,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_Yscale(self, channel_name, channel_number):
         """Add a channel Yscale.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:SCAle`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:SCAle`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -502,14 +470,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_Yoffset(self, channel_name, channel_number):
         """Add a channel Yoffset.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:OFFSet`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:OFFSet`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -527,14 +489,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_Yposition(self, channel_name, channel_number):
         """Add a channel Yposition.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:POSition`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:POSition`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -552,14 +508,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_impedance(self, channel_name, channel_number):
         """Add a channel impedance.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:CH`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:CH`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -586,14 +536,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_units(self, channel_name, channel_number):
         """Add a channel units.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:YUNits`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:YUNits`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -622,14 +566,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_coupling(self, channel_name, channel_number):
         """Add a channel coupling.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:COUPling`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:COUPling`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
             channel_number: Physical channel number.
@@ -656,14 +594,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_Xrange(self, channel_name):
         """Xrange = SCALE x 10.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``HORizontal:SCALE`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -683,14 +615,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_Xscale(self, channel_name):
         """Add a channel Xscale.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``HORizontal:SCALE`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -707,14 +633,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_Xposition(self, channel_name):
         """Add a channel Xposition.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``HORizontal:DELay:TIMe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -735,14 +655,8 @@ class tektronix_4104b(scpi_instrument, delegator):
     # TODO - for check on actual scope
     def add_channel_Xreference(self, channel_name):
         """Add a channel Xreference.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``HORizontal:POSition`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -776,14 +690,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_runmode(self, channel_name):  # TODO - for check on actual scope
         """Add a channel runmode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``ACQuire:STATE`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -818,14 +726,8 @@ class tektronix_4104b(scpi_instrument, delegator):
     # TODO Needs operation complete
     def add_channel_triggerlevel(self, channel_name):
         """Add a channel triggerlevel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``TRIGger:A:LEVel:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -846,14 +748,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_triggermode(self, channel_name):
         """Add a channel triggermode.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``TRIGger:A:MODe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -878,14 +774,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_triggerslope(self, channel_name):
         """Add a channel triggerslope.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the `` Trigger`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -911,14 +801,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_triggersource(self, channel_name):
         """Add a channel triggersource.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``TRIGger:A:EDGE:SOUrce`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -962,14 +846,8 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_acquire_type(self, channel_name):
         """Add a channel acquire type.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``ACQuire:MODe`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -1010,14 +888,8 @@ class tektronix_4104b(scpi_instrument, delegator):
     # number of acquisitions for averaging
     def add_channel_acquire_count(self, channel_name):
         """Add a channel acquire count.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Sends the ``ACQuire:NUMAVg`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -1040,15 +912,7 @@ class tektronix_4104b(scpi_instrument, delegator):
 
     def add_channel_pointcount(self, channel_name):
         """Add a channel pointcount.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/temperature_chamber.py
+++ b/PyICe/lab_instruments/temperature_chamber.py
@@ -49,11 +49,7 @@ class temperature_chamber(instrument, metaclass=ABCMeta):
 
     def add_channel(self, channel_name):
         """Adds just the main temperature setting setpoint channel.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -64,15 +60,7 @@ class temperature_chamber(instrument, metaclass=ABCMeta):
 
     def add_channel_temp(self, channel_name):
         """Channel_name represents PID loop forcing temperature setpoint.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -88,15 +76,7 @@ class temperature_chamber(instrument, metaclass=ABCMeta):
 
     def add_channel_sense(self, channel_name):
         """Channel_name represents primary PID control loop thermocouple readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -111,14 +91,8 @@ class temperature_chamber(instrument, metaclass=ABCMeta):
 
     def add_channel_soak(self, channel_name):
         """Channel_name represents soak time setpoint in seconds. Soak timer runs while temperature is continuously within 'window' and resets to zero otherwise.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
 
@@ -133,14 +107,8 @@ class temperature_chamber(instrument, metaclass=ABCMeta):
 
     def add_channel_window(self, channel_name):
         """Channel_name represents width setpoint of tolerance window to start soak timer. Setpoint is total window width in degrees (temp must be +/-window/2).
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
 
@@ -155,15 +123,7 @@ class temperature_chamber(instrument, metaclass=ABCMeta):
 
     def add_channel_soak_settling_time(self, channel_name):
         """Channel_name represents soak timer elapsed time readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -177,14 +137,8 @@ class temperature_chamber(instrument, metaclass=ABCMeta):
 
     def add_channel_settle_time_limit(self, channel_name):
         """Channel_name represents max time to wait for oven to settle to within window before raising Exception.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
 
@@ -200,14 +154,8 @@ class temperature_chamber(instrument, metaclass=ABCMeta):
 
     def add_channel_blocking(self, channel_name):
         """Allow Python to continue immediately for gui/interactive use without waiting for slew/settle.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Sends the ``:`` SCPI command to the instrument.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
+        Sends the ``:`` SCPI command to the instrument.
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/temptronic_4310.py
+++ b/PyICe/lab_instruments/temptronic_4310.py
@@ -74,15 +74,7 @@ class temptronic_4310(instrument):
 
     def add_channel_temp(self, channel_name):
         """Channel_name represents PID loop forcing temperature setpoint.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -96,15 +88,7 @@ class temptronic_4310(instrument):
 
     def add_channel_sense_dut(self, channel_name):
         """Channel_name represents primary PID control loop thermocouple readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -118,15 +102,7 @@ class temptronic_4310(instrument):
 
     def add_channel_sense_air(self, channel_name):
         """Channel_name represents secondary air stream thermocouple readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
-        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output. Sends the appropriate SCPI configuration commands to the hardware.
-
+        Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
         Args:
             channel_name: Name for the new channel.
 
@@ -140,15 +116,7 @@ class temptronic_4310(instrument):
 
     def add_channel_soak(self, channel_name):
         """Channel_name represents soak time setpoint in seconds. Soak timer runs while temperature is continuously within 'window' and resets to zero otherwise.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -161,15 +129,7 @@ class temptronic_4310(instrument):
 
     def add_channel_window(self, channel_name):
         """Channel_name represents width setpoint of tolerance window to start soak timer. Setpoint is total window width in degrees (temp must be +/-window/2).
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -182,15 +142,7 @@ class temptronic_4310(instrument):
 
     def add_channel_soak_settling_time(self, channel_name):
         """Channel_name represents soak timer elapsed time readback.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -202,15 +154,7 @@ class temptronic_4310(instrument):
 
     def add_channel_max_air(self, channel_name):
         """Channel_name represents maximum airflow temperature setting.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 
@@ -223,15 +167,7 @@ class temptronic_4310(instrument):
 
     def add_channel_max_air2dut(self, channel_name):
         """Channel_name represents maximum allowed temperature difference between airflow and dut setting.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 

--- a/PyICe/lab_instruments/watlow_f4.py
+++ b/PyICe/lab_instruments/watlow_f4.py
@@ -51,15 +51,7 @@ class watlow_f4(temperature_chamber, modbus_instrument):
 
     def add_channels(self, channel_name):
         """Add a channels.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-        Registers the channel with the parent instrument so that it appears in
-        read-all sweeps and logger output.
-
         Registers the channel with the parent instrument so that it appears in read-all sweeps and logger output.
-
         Args:
             channel_name: Name for the new channel.
 


### PR DESCRIPTION
Repeated "Registers the channel with the parent instrument..." and "Formats and sends the command to the instrument." lines appeared multiple times within the same docstrings (likely an autogeneration artifact). Collapsed to a single instance per docstring.

66 files, ~3700 lines removed.